### PR TITLE
add geth-lighthouse helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To deploy a geth-lighthouse node via helm use the [chart](./charts/geth-lighthou
 1. Uninstall the chart: `helm uninstall geth-lighthouse-node` 
 2. Identify the PersistentVolumeClaim used by the chart: `kubectl get pvc`
 3. Delete the pvc, e.g. `kubectl delete pvc geth-lighthouse-node-0`.
-4. Install the chart with the latest iteration by setting the value `--set ephermy.iteration=<latest-iteration>`: 
+4. Install the chart with the latest iteration by setting the value `--set ephemery.iteration=<latest-iteration>`: 
 
 
 ## Manual deployment

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ docker-compose up
 ```
 Currently it only includes single client pair with automatic restart and needs more work. Feel free to extend it with other options. 
 
+### Kubernetes helm charts
+
+Currently only a geth-lighthouse client pair is supported and retention is not automated.
+
+To deploy a geth-lighthouse node via helm use the [chart](./charts/geth-lighthouse/) included in this repository. More information is available in the included [README.md](./charts/geth-lighthouse/README.md). In order to manually reset the network, follow these steps:
+
+1. Uninstall the chart: `helm uninstall geth-lighthouse-node` 
+2. Identify the PersistentVolumeClaim used by the chart: `kubectl get pvc`
+3. Delete the pvc, e.g. `kubectl delete pvc geth-lighthouse-node-0`.
+4. Install the chart with the latest iteration by setting the value `--set ephermy.iteration=<latest-iteration>`: 
+
+
 ## Manual deployment
 
 If you simply want to run a node on Ephemery, you can manually set this up by following one of the sets of instructions below.

--- a/charts/geth-lighthouse/.helmignore
+++ b/charts/geth-lighthouse/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/geth-lighthouse/Chart.yaml
+++ b/charts/geth-lighthouse/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: geth-lighthouse
+description: Helm chart that spins up a post-merge ethereum node consisting of the go-ethereum (geth) execution client and the lighthouse consensus client.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+icon: https://launchpad.ethereum.org/static/media/gethereum-mascot-circle.75cbd3a5.png
+sources:
+  - https://github.com/ethereum/go-ethereum
+  - https://github.com/sigp/lighthouse
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+maintainers:
+  - name: laibe
+    url: https://github.com/laibe

--- a/charts/geth-lighthouse/README.md
+++ b/charts/geth-lighthouse/README.md
@@ -23,9 +23,9 @@ P2P traffic. When deploying multiple nodes, set the p2p ports accordingly and en
 helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=30304 --set lighthouse.ports.p2p=30104
 ```
 
-## Ephermy
+## ephemery
 
-The ephemeral testnet can be enabled with the following flags: `--set ephermy.enabled=true --set ephermy.iteration=32`.
+The ephemeral testnet can be enabled with the following flags: `--set ephemery.enabled=true --set ephemery.iteration=32`.
 The current iteration is shown on the [project website](https://ephemery.pk910.de/).
 
 NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`
@@ -40,8 +40,8 @@ The testnet rolls back to genesis every two days. Currently a clean way to do th
 | InitContainer.image.repository | string | `"archlinux"` | Container image repository. Archlinux contains curl and openssl. |
 | InitContainer.image.tag | string | `"base-20221211.0.109768"` | Image tag |
 | InitContainer.name | string | `"init-container"` | Init container to set the correct permissions to access data directories.  |
-| ephermy.enabled | bool | `false` | Run geth-lighthouse in the [ephermy testnet](https://github.com/pk910/test-testnet-repo) |
-| ephermy.iteration | int | `32` | Specify the current ephermy release |
+| ephemery.enabled | bool | `false` | Run geth-lighthouse in the [ephemery testnet](https://github.com/pk910/test-testnet-repo) |
+| ephemery.iteration | int | `32` | Specify the current ephemery release |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | geth.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | geth.image.repository | string | `"ethereum/client-go"` | Container image repository |

--- a/charts/geth-lighthouse/README.md
+++ b/charts/geth-lighthouse/README.md
@@ -1,0 +1,109 @@
+# geth-lighthouse
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Helm chart that spins up a post-merge ethereum node consisting of the go-ethereum (geth) execution client and the lighthouse consensus client.
+
+## Source Code
+
+* <https://github.com/ethereum/go-ethereum>
+* <https://github.com/sigp/lighthouse>
+
+## Quick Start
+
+```bash
+# install from local copy
+helm install geth-lighthouse-node charts/geth-lighthouse
+```
+
+NOTE: Service of type NodePort is used by default since otherwise consensus and execution clients will not get an internet-accessible port for
+P2P traffic. When deploying multiple nodes, set the p2p ports accordingly and ensure that there is no port conflict, e.g.:
+
+```bash
+helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=30304 --set lighthouse.ports.p2p=30104
+```
+
+## Ephermy
+
+The ephemeral testnet can be enabled with the following flags: `--set ephermy.enabled=true --set ephermy.iteration=32`.
+The current iteration is shown on the [project website](https://ephemery.pk910.de/).
+
+NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`
+
+The testnet rolls back to genesis every two days. Currently a clean way to do that is via `helm uninstall` and `kubectl delete pvc`.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| InitContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| InitContainer.image.repository | string | `"archlinux"` | Container image repository. Archlinux contains curl and openssl. |
+| InitContainer.image.tag | string | `"base-20221211.0.109768"` | Image tag |
+| InitContainer.name | string | `"init-container"` | Init container to set the correct permissions to access data directories.  |
+| ephermy.enabled | bool | `false` | Run geth-lighthouse in the [ephermy testnet](https://github.com/pk910/test-testnet-repo) |
+| ephermy.iteration | int | `32` | Specify the current ephermy release |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| geth.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| geth.image.repository | string | `"ethereum/client-go"` | Container image repository |
+| geth.image.tag | string | `"v1.10.26"` | Image tag |
+| geth.jsonRpcInterface | string | `"0.0.0.0"` | Specify the listen address of the JSON-RPC API server for the execution client. |
+| geth.livenessProbe.initialDelaySeconds | int | `60` |  |
+| geth.livenessProbe.periodSeconds | int | `120` |  |
+| geth.livenessProbe.tcpSocket.port | int | `8545` | Liveness probe tcpSocket port, default is the geth JSON-RPC port |
+| geth.name | string | `"geth"` | Name of the container |
+| geth.ports.httpJsonRpc | int | `8545` | [Execution-API](https://github.com/ethereum/execution-apis) port |
+| geth.ports.metrics | int | `6060` |  |
+| geth.ports.p2p | int | `30303` | TCP and UDP P2P port: place in range 30000-32767 and verify that no existing nodes use these ports |
+| geth.readinessProbe.initialDelaySeconds | int | `60` |  |
+| geth.readinessProbe.periodSeconds | int | `10` |  |
+| geth.readinessProbe.tcpSocket.port | int | `8545` | Readiness probe tcpSocket port, default is the geth JSON-RPC port |
+| geth.resources | object | `{"requests":{"cpu":"4000m","memory":"16Gi"}}` | Resource requests and limits |
+| geth.serviceMonitor.interval | string | `"30s"` |  |
+| geth.serviceMonitor.path | string | `"/debug/metrics/prometheus"` |  |
+| geth.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
+| global.affinity | object | `{}` |  |
+| global.containerSecurityContext | object | `{}` |  |
+| global.engineRpcPort | int | `8551` | Engine API JSON-RPC Port, see also the official [Engine Specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md) |
+| global.imagePullSecrets | list | `[]` | A list of pull secrets is used when credentials are needed to access a container registry with username and password. |
+| global.network | string | `"mainnet"` | Ethereum default network |
+| global.nodeSelector | object | `{}` |  |
+| global.persistence | object | `{"accessModes":["ReadWriteOnce"],"size":"2000Gi","storageClassName":null}` | PVC settings  |
+| global.persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
+| global.persistence.size | string | `"2000Gi"` | Requested size for volume claim template. When using OpenEBS Local PV Device this ensures that a block device with sufficient storage is selected. |
+| global.persistence.storageClassName | string | `nil` | Use a specific storage class. |
+| global.podAnnotations | object | `{}` |  |
+| global.rbac.clusterRules[0].apiGroups[0] | string | `""` |  |
+| global.rbac.clusterRules[0].resources[0] | string | `"nodes"` |  |
+| global.rbac.clusterRules[0].verbs[0] | string | `"get"` |  |
+| global.rbac.clusterRules[0].verbs[1] | string | `"list"` |  |
+| global.rbac.clusterRules[0].verbs[2] | string | `"watch"` |  |
+| global.securityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | Security Context |
+| global.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| global.serviceAccount.create | bool | `true` | Enable service account (Note: Service Account will only be automatically created if `global.serviceAccount.name` is not set) |
+| global.serviceAccount.name | string | `""` | Name of an already existing service account. Setting this value disables the automatic service account creation |
+| global.serviceMonitor.create | bool | `false` |  |
+| global.statefulSetAnnotations | object | `{}` |  |
+| global.terminationGracePeriodSeconds | int | `300` |  |
+| global.tolerations | list | `[]` |  |
+| global.updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |
+| lighthouse.checkpointSync.enabled | bool | `false` |  |
+| lighthouse.checkpointSync.url | string | `"https://beaconstate.info"` |  |
+| lighthouse.httpRestInterface | string | `"0.0.0.0"` | Specify the listen address of the lighthouse REST API server for the consensus client. |
+| lighthouse.image.pullPolicy | string | `"IfNotPresent"` |  |
+| lighthouse.image.repository | string | `"sigp/lighthouse"` | Container image repository |
+| lighthouse.image.tag | string | `"v3.3.0"` | Image tag |
+| lighthouse.livenessProbe.initialDelaySeconds | int | `60` |  |
+| lighthouse.livenessProbe.periodSeconds | int | `120` |  |
+| lighthouse.livenessProbe.tcpSocket.port | int | `5052` | Liveness probe tcpSocket port, default is the lighthouse httpRest port. |
+| lighthouse.name | string | `"lighthouse"` | Name of the container |
+| lighthouse.ports.httpRest | int | `5052` | [Beacon-API](https://ethereum.github.io/beacon-APIs/) port |
+| lighthouse.ports.metrics | int | `5054` |  |
+| lighthouse.ports.p2p | int | `30103` | TCP and UDP P2P port: place in range 30000-32767 and verify that no existing nodes use these ports |
+| lighthouse.readinessProbe.initialDelaySeconds | int | `60` |  |
+| lighthouse.readinessProbe.periodSeconds | int | `10` |  |
+| lighthouse.readinessProbe.tcpSocket.port | int | `5052` | Readiness probe tcpSocket port, default is the lighthouse httpRest port. |
+| lighthouse.resources | object | `{}` | Resource requests and limits |
+| lighthouse.serviceMonitor.interval | string | `"30s"` |  |
+| lighthouse.serviceMonitor.path | string | `"/metrics"` |  |
+| lighthouse.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
+| nameOverride | string | `""` | Overrides the chart's name |

--- a/charts/geth-lighthouse/README.md
+++ b/charts/geth-lighthouse/README.md
@@ -25,12 +25,12 @@ helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=
 
 ## ephemery
 
-The ephemeral testnet can be enabled with the following flags: `--set ephemery.enabled=true --set ephemery.iteration=32`.
+The ephemeral testnet can be enabled with the following flag: `--set ephemery.enabled=true`.
 The current iteration is shown on the [project website](https://ephemery.pk910.de/).
 
 NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`
 
-The testnet rolls back to genesis every two days. Currently a clean way to do that is via `helm uninstall` and `kubectl delete pvc`.
+The testnet rolls back to genesis every two days. Rollback is automated via a CronJob that checks every hour if there is a new release.
 
 ## Values
 

--- a/charts/geth-lighthouse/README.md
+++ b/charts/geth-lighthouse/README.md
@@ -1,6 +1,6 @@
 # geth-lighthouse
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart that spins up a post-merge ethereum node consisting of the go-ethereum (geth) execution client and the lighthouse consensus client.
 
@@ -25,7 +25,7 @@ helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=
 
 ## ephemery
 
-The ephemeral testnet can be enabled with the following flag: `--set ephemery.enabled=true`.
+The ephemeral testnet can be enabled with the following flag: `--set global.network=ephemery`.
 The current iteration is shown on the [project website](https://ephemery.pk910.de/).
 
 NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`
@@ -40,8 +40,11 @@ The testnet rolls back to genesis every two days. Rollback is automated via a Cr
 | InitContainer.image.repository | string | `"archlinux"` | Container image repository. Archlinux contains curl and openssl. |
 | InitContainer.image.tag | string | `"base-20221211.0.109768"` | Image tag |
 | InitContainer.name | string | `"init-container"` | Init container to set the correct permissions to access data directories.  |
-| ephemery.enabled | bool | `false` | Run geth-lighthouse in the [ephemery testnet](https://github.com/pk910/test-testnet-repo) |
-| ephemery.iteration | int | `32` | Specify the current ephemery release |
+| ephemery.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| ephemery.image.repository | string | `"nixery.dev/shell/gnutar/gzip/curl/jq/kubectl/gawk"` | Nixery.dev image |
+| ephemery.image.tag | string | `"latest"` | Image tag |
+| ephemery.name | string | `"ephemery-init"` | Name of the ephemery container |
+| ephemery.repository | string | `"pk910/test-testnet-repo"` | Specify ephemery github repository |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | geth.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | geth.image.repository | string | `"ethereum/client-go"` | Container image repository |
@@ -65,24 +68,18 @@ The testnet rolls back to genesis every two days. Rollback is automated via a Cr
 | global.containerSecurityContext | object | `{}` |  |
 | global.engineRpcPort | int | `8551` | Engine API JSON-RPC Port, see also the official [Engine Specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md) |
 | global.imagePullSecrets | list | `[]` | A list of pull secrets is used when credentials are needed to access a container registry with username and password. |
-| global.network | string | `"mainnet"` | Ethereum default network |
+| global.network | string | `"mainnet"` | Ethereum default network. Example: mainnet, goerli, ephemery |
 | global.nodeSelector | object | `{}` |  |
 | global.persistence | object | `{"accessModes":["ReadWriteOnce"],"size":"2000Gi","storageClassName":null}` | PVC settings  |
 | global.persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | global.persistence.size | string | `"2000Gi"` | Requested size for volume claim template. When using OpenEBS Local PV Device this ensures that a block device with sufficient storage is selected. |
 | global.persistence.storageClassName | string | `nil` | Use a specific storage class. |
 | global.podAnnotations | object | `{}` |  |
-| global.rbac.clusterRules[0].apiGroups[0] | string | `""` |  |
-| global.rbac.clusterRules[0].resources[0] | string | `"nodes"` |  |
-| global.rbac.clusterRules[0].verbs[0] | string | `"get"` |  |
-| global.rbac.clusterRules[0].verbs[1] | string | `"list"` |  |
-| global.rbac.clusterRules[0].verbs[2] | string | `"watch"` |  |
 | global.securityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | Security Context |
 | global.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | global.serviceAccount.create | bool | `true` | Enable service account (Note: Service Account will only be automatically created if `global.serviceAccount.name` is not set) |
 | global.serviceAccount.name | string | `""` | Name of an already existing service account. Setting this value disables the automatic service account creation |
 | global.serviceMonitor.create | bool | `false` |  |
-| global.statefulSetAnnotations | object | `{}` |  |
 | global.terminationGracePeriodSeconds | int | `300` |  |
 | global.tolerations | list | `[]` |  |
 | global.updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |

--- a/charts/geth-lighthouse/README.md.gotmpl
+++ b/charts/geth-lighthouse/README.md.gotmpl
@@ -1,0 +1,36 @@
+{{ template "chart.header" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.sourcesSection" . }}
+{{ template "chart.requirementsSection" . }}
+
+## Quick Start
+
+```bash
+# install from local copy
+helm install geth-lighthouse-node charts/geth-lighthouse
+```
+
+NOTE: Service of type NodePort is used by default since otherwise consensus and execution clients will not get an internet-accessible port for 
+P2P traffic. When deploying multiple nodes, set the p2p ports accordingly and ensure that there is no port conflict, e.g.:
+
+```bash
+helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=30304 --set lighthouse.ports.p2p=30104
+```
+
+## Ephermy 
+
+The ephemeral testnet can be enabled with the following flags: `--set ephermy.enabled=true --set ephermy.iteration=32`.
+The current iteration is shown on the [project website](https://ephemery.pk910.de/). 
+
+NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`
+
+The testnet rolls back to genesis every two days. Currently a clean way to do that is via `helm uninstall` and `kubectl delete pvc`.
+
+
+{{ template "chart.valuesSection" . }}

--- a/charts/geth-lighthouse/README.md.gotmpl
+++ b/charts/geth-lighthouse/README.md.gotmpl
@@ -23,9 +23,9 @@ P2P traffic. When deploying multiple nodes, set the p2p ports accordingly and en
 helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=30304 --set lighthouse.ports.p2p=30104
 ```
 
-## Ephermy 
+## ephemery 
 
-The ephemeral testnet can be enabled with the following flags: `--set ephermy.enabled=true --set ephermy.iteration=32`.
+The ephemeral testnet can be enabled with the following flags: `--set ephemery.enabled=true --set ephemery.iteration=32`.
 The current iteration is shown on the [project website](https://ephemery.pk910.de/). 
 
 NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`

--- a/charts/geth-lighthouse/README.md.gotmpl
+++ b/charts/geth-lighthouse/README.md.gotmpl
@@ -25,7 +25,7 @@ helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=
 
 ## ephemery 
 
-The ephemeral testnet can be enabled with the following flag: `--set ephemery.enabled=true`.
+The ephemeral testnet can be enabled with the following flag: `--set global.network=ephemery`.
 The current iteration is shown on the [project website](https://ephemery.pk910.de/). 
 
 NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`

--- a/charts/geth-lighthouse/README.md.gotmpl
+++ b/charts/geth-lighthouse/README.md.gotmpl
@@ -25,12 +25,12 @@ helm install geth-lighthouse-node-1 charts/geth-lighthouse --set geth.ports.p2p=
 
 ## ephemery 
 
-The ephemeral testnet can be enabled with the following flags: `--set ephemery.enabled=true --set ephemery.iteration=32`.
+The ephemeral testnet can be enabled with the following flag: `--set ephemery.enabled=true`.
 The current iteration is shown on the [project website](https://ephemery.pk910.de/). 
 
 NOTE: Since the ephemeral testnet is small, the requested storage size can be reduced: `--set global.persistence.size=10Gi`
 
-The testnet rolls back to genesis every two days. Currently a clean way to do that is via `helm uninstall` and `kubectl delete pvc`.
+The testnet rolls back to genesis every two days. Rollback is automated via a CronJob that checks every hour if there is a new release.
 
 
 {{ template "chart.valuesSection" . }}

--- a/charts/geth-lighthouse/templates/_helpers.tpl
+++ b/charts/geth-lighthouse/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "geth-lighthouse.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "geth-lighthouse.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "geth-lighthouse.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "geth-lighthouse.labels" -}}
+helm.sh/chart: {{ include "geth-lighthouse.chart" . }}
+{{ include "geth-lighthouse.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "geth-lighthouse.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "geth-lighthouse.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "geth-lighthouse.serviceAccountName" -}}
+{{- if .Values.global.serviceAccount.create }}
+{{- default (include "geth-lighthouse.fullname" .) .Values.global.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.global.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/geth-lighthouse/templates/clusterrole.yaml
+++ b/charts/geth-lighthouse/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+rules:
+{{- toYaml .Values.global.rbac.clusterRules | nindent 0 }}

--- a/charts/geth-lighthouse/templates/clusterrole.yaml
+++ b/charts/geth-lighthouse/templates/clusterrole.yaml
@@ -1,8 +1,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "geth-lighthouse.serviceAccountName" . }}
-  labels:
-    {{- include "geth-lighthouse.labels" . | nindent 4 }}
-rules:
-{{- toYaml .Values.global.rbac.clusterRules | nindent 0 }}

--- a/charts/geth-lighthouse/templates/clusterrolebinding.yaml
+++ b/charts/geth-lighthouse/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "geth-lighthouse.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/geth-lighthouse/templates/cronjob.yaml
+++ b/charts/geth-lighthouse/templates/cronjob.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ephemery.enabled }}
+# ephemery resetter cron job that restarts the pod every two days
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "geth-lighthouse.fullname" . }}
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ include "geth-lighthouse.serviceAccountName" . }}
+          restartPolicy: Never
+          containers:
+          - name:  resetter
+            image: "{{ .Values.ephemery.image.repository }}:{{ .Values.ephemery.image.tag }}"
+            imagePullPolicy: {{ .Values.ephemery.image.pullPolicy }}
+            command:
+            - bash
+            - -c
+            - >
+              ITERATION_NUMBER=$(curl -s https://api.github.com/repos/{{ .Values.ephemery.repository }}/releases/latest | jq -r '.tag_name' | awk -F- '{print $2}');
+              CURRENT_ITERATION=$(kubectl get sts {{ include "geth-lighthouse.fullname" .}} -o json| jq '.metadata.annotations.iteration | tonumber');
+              echo "current iteration: $CURRENT_ITERATION";
+              echo "latest iteration: $ITERATION_NUMBER";
+              if [ $ITERATION_NUMBER -gt $CURRENT_ITERATION ]; then kubectl rollout restart sts/{{ include "geth-lighthouse.fullname" . }}; fi;
+          restartPolicy: OnFailure
+{{- end }}

--- a/charts/geth-lighthouse/templates/role.yaml
+++ b/charts/geth-lighthouse/templates/role.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.ephemery.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+rules:
+    - apiGroups: ["apps", "extensions"]
+      resources: ["statefulsets"]
+      resourceNames: 
+      - "{{ include "geth-lighthouse.fullname" . }}"
+      verbs: ["get", "patch", "list", "watch"]
+{{- end }}

--- a/charts/geth-lighthouse/templates/rolebinding.yaml
+++ b/charts/geth-lighthouse/templates/rolebinding.yaml
@@ -1,14 +1,16 @@
+{{- if .Values.ephemery.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "geth-lighthouse.serviceAccountName" . }}
   labels:
     {{- include "geth-lighthouse.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "geth-lighthouse.serviceAccountName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "geth-lighthouse.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/geth-lighthouse/templates/service-headless.yaml
+++ b/charts/geth-lighthouse/templates/service-headless.yaml
@@ -1,0 +1,28 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "geth-lighthouse.fullname" . }}-headless
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.geth.ports.httpJsonRpc }}
+      targetPort: {{ .Values.geth.ports.httpJsonRpc }}
+      protocol: TCP
+      name: geth-http-rpc
+    - port: {{ .Values.geth.ports.metrics }}
+      targetPort: {{ .Values.geth.ports.metrics }}
+      protocol: TCP
+      name: geth-metrics
+    - port: {{ .Values.lighthouse.ports.httpRest }}
+      targetPort: {{ .Values.lighthouse.ports.httpRest }}
+      protocol: TCP
+      name: lh-http-rest
+    - port: {{ .Values.lighthouse.ports.metrics }}
+      targetPort: {{ .Values.lighthouse.ports.metrics }}
+      protocol: TCP
+      name: lh-metrics
+  selector:
+    {{- include "geth-lighthouse.selectorLabels" . | nindent 4 }}

--- a/charts/geth-lighthouse/templates/service-nodeport-p2p.yaml
+++ b/charts/geth-lighthouse/templates/service-nodeport-p2p.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "geth-lighthouse.labels" $ | nindent 4 }}
     pod: {{ include "geth-lighthouse.fullname" $ }}-0
-    type: p2p
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/charts/geth-lighthouse/templates/service-nodeport-p2p.yaml
+++ b/charts/geth-lighthouse/templates/service-nodeport-p2p.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "geth-lighthouse.fullname" . }}-p2p
+  labels:
+    {{- include "geth-lighthouse.labels" $ | nindent 4 }}
+    pod: {{ include "geth-lighthouse.fullname" $ }}-0
+    type: p2p
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+    - port: {{ .Values.geth.ports.p2p}}
+      targetPort: geth-p2p-udp
+      nodePort: {{ .Values.geth.ports.p2p}}
+      protocol: UDP
+      name: geth-p2p-udp
+    - port: {{ .Values.geth.ports.p2p}}
+      targetPort: geth-p2p-tcp
+      nodePort: {{ .Values.geth.ports.p2p}}
+      protocol: TCP
+      name: geth-p2p-tcp
+    - port: {{ .Values.lighthouse.ports.p2p}}
+      targetPort: lh-p2p-udp
+      nodePort: {{ .Values.lighthouse.ports.p2p}}
+      protocol: UDP
+      name: lh-p2p-udp
+    - port: {{ .Values.lighthouse.ports.p2p}}
+      targetPort: lh-p2p-tcp
+      nodePort: {{ .Values.lighthouse.ports.p2p}}
+      protocol: TCP
+      name: lh-p2p-tcp
+  selector:
+    {{- include "geth-lighthouse.selectorLabels" . | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: "{{ include "geth-lighthouse.fullname" $ }}-0"

--- a/charts/geth-lighthouse/templates/service.yaml
+++ b/charts/geth-lighthouse/templates/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "geth-lighthouse.fullname" . }}
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  # Note Engine API port is NOT exposed. After the Merge Execution Client and Consenus Client have strict 1:1 mapping
+  ports:
+    - port: {{ .Values.geth.ports.httpJsonRpc }}
+      targetPort: {{ .Values.geth.ports.httpJsonRpc }}
+      protocol: TCP
+      name: geth-http-rpc
+    - port: {{ .Values.geth.ports.metrics }}
+      targetPort: {{ .Values.geth.ports.metrics }}
+      protocol: TCP
+      name: geth-metrics
+    - port: {{ .Values.lighthouse.ports.httpRest }}
+      targetPort: {{ .Values.lighthouse.ports.httpRest }}
+      protocol: TCP
+      name: lh-http-rest
+    - port: {{ .Values.lighthouse.ports.metrics }}
+      targetPort: {{ .Values.lighthouse.ports.metrics }}
+      protocol: TCP
+      name: lh-metrics
+  selector:
+    {{- include "geth-lighthouse.selectorLabels" . | nindent 4 }}

--- a/charts/geth-lighthouse/templates/serviceaccount.yaml
+++ b/charts/geth-lighthouse/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.global.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/geth-lighthouse/templates/servicemonitor.yaml
+++ b/charts/geth-lighthouse/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.global.serviceMonitor.create -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  # geth
+  - interval: {{ .Values.geth.serviceMonitor.interval }}
+    {{- if .Values.geth.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.geth.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: geth-metrics
+    path: {{ .Values.geth.serviceMonitor.path }}
+  # lighthouse
+  - interval: {{ .Values.lighthouse.serviceMonitor.interval }}
+    {{- if .Values.lighthouse.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.lighthouse.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: lh-metrics
+    path: {{ .Values.lighthouse.serviceMonitor.path }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "geth-lighthouse.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/geth-lighthouse/templates/statefulset.yaml
+++ b/charts/geth-lighthouse/templates/statefulset.yaml
@@ -10,6 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- include "geth-lighthouse.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "geth-lighthouse.fullname" . }}-headless
   updateStrategy:
     {{- toYaml .Values.global.updateStrategy | nindent 4 }}
   template:
@@ -55,7 +56,7 @@ spec:
             - name: storage
               mountPath: "/data"
         # Ephemery testnet specific init containers
-        {{- if .Values.ephemery.enabled }}
+        {{- if eq .Values.global.network "ephemery" }}
         - name: {{ .Values.ephemery.name }}
           image: "{{ .Values.ephemery.image.repository }}:{{ .Values.ephemery.image.tag }}"
           securityContext:
@@ -111,14 +112,14 @@ spec:
             - -ac
             - >
               . /data/common/publicip.env;
-              {{- if .Values.ephemery.enabled }}
+              {{- if eq .Values.global.network "ephemery" }}
               . /data/common/ephemery/nodevars_env.txt;
               {{- end }}
               exec geth
-              {{- if not .Values.ephemery.enabled }}
+              {{- if ne .Values.global.network "ephemery" }}
               --{{ .Values.global.network }}
               {{- end }}
-              {{- if .Values.ephemery.enabled }}
+              {{- if eq .Values.global.network "ephemery" }}
               --networkid=$CHAIN_ID
               --bootnodes=$BOOTNODE_ENODE_LIST
               --syncmode=full
@@ -173,16 +174,16 @@ spec:
             - -ac
             - >
               . /data/common/publicip.env;
-              {{- if .Values.ephemery.enabled }}
+              {{- if eq .Values.global.network "ephemery" }}
               . /data/common/ephemery/nodevars_env.txt;
               rm -r /data/lighthouse/beacon;
               {{- end }}
               exec lighthouse
-              {{- if not .Values.ephemery.enabled }}
+               {{- if ne .Values.global.network "ephemery" }}
               --network={{ .Values.global.network }}
               {{- end }}
               bn
-              {{- if .Values.ephemery.enabled }}
+              {{- if eq .Values.global.network "ephemery" }}
               --boot-nodes=$BOOTNODE_ENR_LIST
               --testnet-dir=/data/common/ephemery/
               {{- end }}

--- a/charts/geth-lighthouse/templates/statefulset.yaml
+++ b/charts/geth-lighthouse/templates/statefulset.yaml
@@ -1,0 +1,237 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "geth-lighthouse.fullname" . }}
+  labels:
+    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.global.statefulSetAnnotations | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "geth-lighthouse.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    {{- toYaml .Values.global.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "geth-lighthouse.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "geth-lighthouse.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.global.securityContext | nindent 8 }}
+      initContainers:
+        # InitContainer
+        - name: init
+          image: "{{ .Values.InitContainer.image.repository }}:{{ .Values.InitContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.InitContainer.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          # Chown data directory, generate jwt for execution client <-> consensus client communication and get external ip for p2p
+          # Optionally load latest ephermy config
+          command: 
+            - bash
+            - -c
+            - >
+              chown -R 1001:1001 /data;
+              mkdir -p /data/common;
+              openssl rand -hex 32 > /data/common/jwt.hex;
+              echo -n PUBLIC_IP=$(curl http://icanhazip.com) > /data/common/publicip.env;
+              cat /data/common/publicip.env;
+              {{- if .Values.ephermy.enabled }}
+              mkdir -p /data/common/ephermy && cd /data/common/ephermy;
+              curl -L https://github.com/pk910/test-testnet-repo/releases/download/ephemery-{{ .Values.ephermy.iteration }}/testnet-all.tar.gz > testnet-all.tar.gz;
+              tar xzvf testnet-all.tar.gz;
+              cat nodevars_env.txt;
+              {{- end }}
+          volumeMounts:
+            - name: storage
+              mountPath: "/data"
+        # Geth init for ephermy testnet
+        {{- if .Values.ephermy.enabled }}
+        - name: geth-init
+          securityContext: 
+           {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.geth.image.repository }}:{{ .Values.geth.image.tag }}"
+          imagePullPolicy: {{ .Values.geth.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              exec geth init
+              --datadir=/data/geth
+              /data/common/ephermy/genesis.json
+          volumeMounts:
+            - name: storage
+              mountPath: "/data/geth"
+              subPath: geth
+            - name: storage
+              mountPath: "/data/common"
+              subPath: common
+         {{- end }}
+      containers:
+        # Geth container
+        - name: {{ .Values.geth.name }}
+          securityContext: 
+           {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.geth.image.repository }}:{{ .Values.geth.image.tag }}"
+          imagePullPolicy: {{ .Values.geth.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              . /data/common/publicip.env;
+              {{- if .Values.ephermy.enabled }}
+              . /data/common/ephermy/nodevars_env.txt;
+              {{- end }}
+              exec geth
+              {{- if not .Values.ephermy.enabled }}
+              --{{ .Values.global.network }}
+              {{- end }}
+              {{- if .Values.ephermy.enabled }}
+              --networkid=$CHAIN_ID
+              --bootnodes=$BOOTNODE_ENODE_LIST
+              {{- end }}
+              --nat=extip:$PUBLIC_IP
+              --port={{ .Values.geth.ports.p2p }}
+              --datadir=/data/geth
+              --metrics
+              --metrics.addr=0.0.0.0
+              --metrics.port="{{ .Values.geth.ports.metrics }}"
+              --authrpc.jwtsecret=/data/common/jwt.hex
+              --authrpc.port={{ .Values.global.engineRpcPort }}
+              --http.vhosts=*
+              --http
+              --http.addr=0.0.0.0
+              --http.port={{ .Values.geth.ports.httpJsonRpc }}
+          volumeMounts:
+            - name: storage
+              mountPath: "/data/geth"
+              subPath: geth
+            - name: storage
+              mountPath: "/data/common"
+              subPath: common
+              readOnly: true
+          ports:
+            - name: geth-p2p-tcp
+              containerPort: {{ .Values.geth.ports.p2p }}
+              protocol: TCP
+            - name: geth-p2p-udp
+              containerPort: {{ .Values.geth.ports.p2p }}
+              protocol: UDP
+            - name: geth-http-rpc
+              containerPort: {{ .Values.geth.ports.httpJsonRpc }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.geth.ports.metrics }}
+          livenessProbe:
+            {{- toYaml .Values.geth.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.geth.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.geth.resources | nindent 12 }}
+        # Lighthouse container
+        - name: {{ .Values.lighthouse.name }}
+          securityContext: 
+           {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.lighthouse.image.repository }}:{{ .Values.lighthouse.image.tag }}"
+          imagePullPolicy: {{ .Values.lighthouse.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              . /data/common/publicip.env;
+              {{- if .Values.ephermy.enabled }}
+              . /data/common/ephermy/nodevars_env.txt;
+              {{- end }}
+              exec lighthouse
+              {{- if not .Values.ephermy.enabled }}
+              --network={{ .Values.global.network }}
+              {{- end }}
+              bn
+              {{- if .Values.ephermy.enabled }}
+              --boot-nodes=$BOOTNODE_ENR_LIST
+              --testnet-dir=/data/common/ephermy/
+              {{- end }}
+              --port={{ .Values.lighthouse.ports.p2p }}
+              --disable-upnp
+              --disable-enr-auto-update
+              --enr-address=$PUBLIC_IP
+              --enr-tcp-port={{ .Values.lighthouse.ports.p2p }}
+              --enr-udp-port={{ .Values.lighthouse.ports.p2p }}
+              --staking
+              --datadir=/data/lighthouse
+              --execution-endpoint=http://127.0.0.1:{{ .Values.global.engineRpcPort }}
+              --execution-jwt=/data/common/jwt.hex 
+              --http 
+              --http-address={{ .Values.lighthouse.httpRestInterface }}
+              --http-port={{ .Values.lighthouse.ports.httpRest }}
+              {{- if .Values.lighthouse.checkpointSync.enabled }}
+              --checkpoint-sync-url={{ .Values.lighthouse.checkpointSync.url }}
+              {{- end }}
+              --prune-payloads=false
+              --metrics
+              --metrics-allow-origin=*
+              --metrics-address=0.0.0.0
+              --metrics-port="{{ .Values.lighthouse.ports.metrics }}"
+              --validator-monitor-auto
+          volumeMounts:
+            - name: storage
+              mountPath: "/data/lighthouse"
+              subPath: lighthouse
+            - name: storage
+              mountPath: "/data/common"
+              subPath: common
+              readOnly: true
+          ports:
+            - name: lh-p2p-tcp
+              containerPort: {{ .Values.lighthouse.ports.p2p }}
+              protocol: TCP
+            - name: lh-p2p-udp
+              containerPort: {{ .Values.lighthouse.ports.p2p }}
+              protocol: UDP
+            - name: lh-http-rest
+              containerPort: {{ .Values.lighthouse.ports.httpRest }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.lighthouse.ports.metrics }}
+          livenessProbe:
+            {{- toYaml .Values.lighthouse.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.lighthouse.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.lighthouse.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.global.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.global.terminationGracePeriodSeconds }}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+    spec:
+      accessModes:
+        {{- toYaml .Values.global.persistence.accessModes | nindent 8 }}
+      storageClassName: {{ .Values.global.persistence.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.global.persistence.size }}
+
+

--- a/charts/geth-lighthouse/templates/statefulset.yaml
+++ b/charts/geth-lighthouse/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           # Chown data directory, generate jwt for execution client <-> consensus client communication and get external ip for p2p
-          # Optionally load latest ephermy config
+          # Optionally load latest ephemery config
           command: 
             - bash
             - -c
@@ -52,17 +52,17 @@ spec:
               openssl rand -hex 32 > /data/common/jwt.hex;
               echo -n PUBLIC_IP=$(curl http://icanhazip.com) > /data/common/publicip.env;
               cat /data/common/publicip.env;
-              {{- if .Values.ephermy.enabled }}
-              mkdir -p /data/common/ephermy && cd /data/common/ephermy;
-              curl -L https://github.com/pk910/test-testnet-repo/releases/download/ephemery-{{ .Values.ephermy.iteration }}/testnet-all.tar.gz > testnet-all.tar.gz;
+              {{- if .Values.ephemery.enabled }}
+              mkdir -p /data/common/ephemery && cd /data/common/ephemery;
+              curl -L https://github.com/pk910/test-testnet-repo/releases/download/ephemery-{{ .Values.ephemery.iteration }}/testnet-all.tar.gz > testnet-all.tar.gz;
               tar xzvf testnet-all.tar.gz;
               cat nodevars_env.txt;
               {{- end }}
           volumeMounts:
             - name: storage
               mountPath: "/data"
-        # Geth init for ephermy testnet
-        {{- if .Values.ephermy.enabled }}
+        # Geth init for ephemery testnet
+        {{- if .Values.ephemery.enabled }}
         - name: geth-init
           securityContext: 
            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
@@ -74,7 +74,7 @@ spec:
             - >
               exec geth init
               --datadir=/data/geth
-              /data/common/ephermy/genesis.json
+              /data/common/ephemery/genesis.json
           volumeMounts:
             - name: storage
               mountPath: "/data/geth"
@@ -95,16 +95,17 @@ spec:
             - -ac
             - >
               . /data/common/publicip.env;
-              {{- if .Values.ephermy.enabled }}
-              . /data/common/ephermy/nodevars_env.txt;
+              {{- if .Values.ephemery.enabled }}
+              . /data/common/ephemery/nodevars_env.txt;
               {{- end }}
               exec geth
-              {{- if not .Values.ephermy.enabled }}
+              {{- if not .Values.ephemery.enabled }}
               --{{ .Values.global.network }}
               {{- end }}
-              {{- if .Values.ephermy.enabled }}
+              {{- if .Values.ephemery.enabled }}
               --networkid=$CHAIN_ID
               --bootnodes=$BOOTNODE_ENODE_LIST
+              --syncmode=full
               {{- end }}
               --nat=extip:$PUBLIC_IP
               --port={{ .Values.geth.ports.p2p }}
@@ -155,17 +156,17 @@ spec:
             - -ac
             - >
               . /data/common/publicip.env;
-              {{- if .Values.ephermy.enabled }}
-              . /data/common/ephermy/nodevars_env.txt;
+              {{- if .Values.ephemery.enabled }}
+              . /data/common/ephemery/nodevars_env.txt;
               {{- end }}
               exec lighthouse
-              {{- if not .Values.ephermy.enabled }}
+              {{- if not .Values.ephemery.enabled }}
               --network={{ .Values.global.network }}
               {{- end }}
               bn
-              {{- if .Values.ephermy.enabled }}
+              {{- if .Values.ephemery.enabled }}
               --boot-nodes=$BOOTNODE_ENR_LIST
-              --testnet-dir=/data/common/ephermy/
+              --testnet-dir=/data/common/ephemery/
               {{- end }}
               --port={{ .Values.lighthouse.ports.p2p }}
               --disable-upnp

--- a/charts/geth-lighthouse/templates/statefulset.yaml
+++ b/charts/geth-lighthouse/templates/statefulset.yaml
@@ -42,7 +42,6 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           # Chown data directory, generate jwt for execution client <-> consensus client communication and get external ip for p2p
-          # Optionally load latest ephemery config
           command: 
             - bash
             - -c
@@ -50,19 +49,35 @@ spec:
               chown -R 1001:1001 /data;
               mkdir -p /data/common;
               openssl rand -hex 32 > /data/common/jwt.hex;
-              echo -n PUBLIC_IP=$(curl http://icanhazip.com) > /data/common/publicip.env;
+              echo -n PUBLIC_IP=$(curl -s http://icanhazip.com) > /data/common/publicip.env;
               cat /data/common/publicip.env;
-              {{- if .Values.ephemery.enabled }}
-              mkdir -p /data/common/ephemery && cd /data/common/ephemery;
-              curl -L https://github.com/pk910/test-testnet-repo/releases/download/ephemery-{{ .Values.ephemery.iteration }}/testnet-all.tar.gz > testnet-all.tar.gz;
-              tar xzvf testnet-all.tar.gz;
-              cat nodevars_env.txt;
-              {{- end }}
           volumeMounts:
             - name: storage
               mountPath: "/data"
-        # Geth init for ephemery testnet
+        # Ephemery testnet specific init containers
         {{- if .Values.ephemery.enabled }}
+        - name: {{ .Values.ephemery.name }}
+          image: "{{ .Values.ephemery.image.repository }}:{{ .Values.ephemery.image.tag }}"
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          imagePullPolicy: {{ .Values.ephemery.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              chown -R 1001:1001 /data;
+              rm -rf /data/commmon/ephemery;
+              mkdir -p /data/common/ephemery && cd /data/common/ephemery;
+              RELEASE=$(curl -s https://api.github.com/repos/{{ .Values.ephemery.repository }}/releases/latest | jq -r '.tag_name');
+              ITERATION=$(echo $RELEASE|awk -F- '{print $2}');
+              kubectl annotate --overwrite sts {{ include "geth-lighthouse.fullname" . }} iteration=$ITERATION;
+              curl -s -L https://github.com/{{ .Values.ephemery.repository }}/releases/download/$RELEASE/testnet-all.tar.gz > testnet-all.tar.gz;
+              tar xzvf testnet-all.tar.gz;
+              cat config.yaml
+          volumeMounts:
+            - name: storage
+              mountPath: "/data"
         - name: geth-init
           securityContext: 
            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
@@ -72,6 +87,7 @@ spec:
             - sh
             - -ac
             - >
+              rm -rf /data/geth/*;
               exec geth init
               --datadir=/data/geth
               /data/common/ephemery/genesis.json
@@ -106,6 +122,7 @@ spec:
               --networkid=$CHAIN_ID
               --bootnodes=$BOOTNODE_ENODE_LIST
               --syncmode=full
+              --snapshot=false
               {{- end }}
               --nat=extip:$PUBLIC_IP
               --port={{ .Values.geth.ports.p2p }}
@@ -158,6 +175,7 @@ spec:
               . /data/common/publicip.env;
               {{- if .Values.ephemery.enabled }}
               . /data/common/ephemery/nodevars_env.txt;
+              rm -r /data/lighthouse/beacon;
               {{- end }}
               exec lighthouse
               {{- if not .Values.ephemery.enabled }}
@@ -234,5 +252,3 @@ spec:
       resources:
         requests:
           storage: {{ .Values.global.persistence.size }}
-
-

--- a/charts/geth-lighthouse/values.yaml
+++ b/charts/geth-lighthouse/values.yaml
@@ -56,16 +56,6 @@ global:
   # ServiceMonitor
   serviceMonitor:
     create: false
-  rbac:
-     clusterRules:
-        # Required to obtain the nodes external IP
-       - apiGroups: [""]
-         resources:
-         - "nodes"
-         verbs:
-         - "get"
-         - "list"
-         - "watch"
 
 # Init Container values
 InitContainer:
@@ -82,8 +72,17 @@ InitContainer:
 ephemery:
   # -- Run geth-lighthouse in the [ephemery testnet](https://github.com/pk910/test-testnet-repo)
   enabled: false
-  # -- Specify the current ephemery release
-  iteration: 32
+  # -- Name of the ephemery container
+  name: ephemery-init
+  # -- Specify ephemery github repository
+  repository: pk910/test-testnet-repo
+  image:
+    # -- Nixery.dev image
+    repository: "nixery.dev/shell/gnutar/gzip/curl/jq/kubectl/gawk"
+    # -- Container pull policy
+    pullPolicy: "IfNotPresent"
+    # -- Image tag
+    tag: latest
 
 # Geth values
 geth:
@@ -175,4 +174,3 @@ lighthouse:
     path: /metrics
     interval: 30s
     scrapeTimeout: 10s
-

--- a/charts/geth-lighthouse/values.yaml
+++ b/charts/geth-lighthouse/values.yaml
@@ -79,10 +79,10 @@ InitContainer:
     # -- Image tag
     tag: "base-20221211.0.109768"
 
-ephermy:
-  # -- Run geth-lighthouse in the [ephermy testnet](https://github.com/pk910/test-testnet-repo)
+ephemery:
+  # -- Run geth-lighthouse in the [ephemery testnet](https://github.com/pk910/test-testnet-repo)
   enabled: false
-  # -- Specify the current ephermy release
+  # -- Specify the current ephemery release
   iteration: 32
 
 # Geth values

--- a/charts/geth-lighthouse/values.yaml
+++ b/charts/geth-lighthouse/values.yaml
@@ -1,0 +1,178 @@
+# Default values for geth-lighthouse.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# Replicas are not supported 
+
+# -- Overrides the chart's name
+nameOverride: ""
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+global:
+  # -- Ethereum default network
+  network: mainnet
+  # -- Engine API JSON-RPC Port, see also the official [Engine Specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md)
+  engineRpcPort: 8551
+  # -- A list of pull secrets is used when credentials are needed to access a container registry with username and password.
+  imagePullSecrets: []
+  podAnnotations: {}
+  # -- Security Context
+  securityContext:
+    fsGroup: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    runAsUser: 1001
+  containerSecurityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+  statefulSetAnnotations: {}
+  updateStrategy:
+    # -- Update stategy type
+    type: RollingUpdate
+  terminationGracePeriodSeconds: 300
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # -- PVC settings 
+  persistence:
+    # -- Access mode for the volume claim template
+    accessModes:
+    - ReadWriteOnce
+    # -- Requested size for volume claim template. When using OpenEBS Local PV Device this ensures that a block device with sufficient storage is selected.
+    size: 2000Gi
+    # -- Use a specific storage class.
+    storageClassName: null
+  serviceAccount:
+    # -- Enable service account (Note: Service Account will only be automatically created if `global.serviceAccount.name` is not set)
+    create: true
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- Name of an already existing service account. Setting this value disables the automatic service account creation
+    name: ""
+  # ServiceMonitor
+  serviceMonitor:
+    create: false
+  rbac:
+     clusterRules:
+        # Required to obtain the nodes external IP
+       - apiGroups: [""]
+         resources:
+         - "nodes"
+         verbs:
+         - "get"
+         - "list"
+         - "watch"
+
+# Init Container values
+InitContainer:
+  # -- Init container to set the correct permissions to access data directories. 
+  name: "init-container"
+  image:
+    # -- Container image repository. Archlinux contains curl and openssl.
+    repository: "archlinux"
+    # -- Container pull policy
+    pullPolicy: "IfNotPresent"
+    # -- Image tag
+    tag: "base-20221211.0.109768"
+
+ephermy:
+  # -- Run geth-lighthouse in the [ephermy testnet](https://github.com/pk910/test-testnet-repo)
+  enabled: false
+  # -- Specify the current ephermy release
+  iteration: 32
+
+# Geth values
+geth:
+  # -- Name of the container
+  name: geth
+  image:
+    # -- Container image repository
+    repository: ethereum/client-go
+    # -- Container pull policy
+    pullPolicy: IfNotPresent
+    # -- Image tag
+    tag: v1.10.26
+  ports:
+    # -- [Execution-API](https://github.com/ethereum/execution-apis) port
+    httpJsonRpc: 8545
+    # -- TCP and UDP P2P port: place in range 30000-32767 and verify that no existing nodes use these ports
+    p2p: 30303
+    metrics: 6060
+  # -- Specify the listen address of the JSON-RPC API server for the execution client.
+  jsonRpcInterface: "0.0.0.0"
+  livenessProbe:
+    tcpSocket:
+      # -- Liveness probe tcpSocket port, default is the geth JSON-RPC port
+      port: 8545
+    initialDelaySeconds: 60
+    periodSeconds: 120
+  # Readiness probe on the default geth JSON-RPC port
+  readinessProbe:
+    tcpSocket:
+      # -- Readiness probe tcpSocket port, default is the geth JSON-RPC port
+      port: 8545
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  # -- Resource requests and limits
+  resources:
+    # TODO: Should we set limits or not?
+    #limits:
+    #  memory: 64Gi
+    requests:
+      cpu: 4000m
+      memory: 16Gi
+  serviceMonitor:
+    path: /debug/metrics/prometheus
+    interval: 30s
+    scrapeTimeout: 10s
+
+# Lighthouse values
+lighthouse:
+  # -- Name of the container
+  name: "lighthouse"
+  image:
+    # -- Container image repository
+    repository: "sigp/lighthouse"
+    pullPolicy: "IfNotPresent"
+    # -- Image tag
+    tag: v3.3.0
+  ports:
+    # -- [Beacon-API](https://ethereum.github.io/beacon-APIs/) port
+    httpRest: 5052
+    # -- TCP and UDP P2P port: place in range 30000-32767 and verify that no existing nodes use these ports
+    p2p: 30103
+    metrics: 5054
+  # -- Specify the listen address of the lighthouse REST API server for the consensus client.
+  httpRestInterface: "0.0.0.0"
+  checkpointSync:
+    enabled: false
+    url: "https://beaconstate.info"
+  livenessProbe:
+    tcpSocket:
+      # -- Liveness probe tcpSocket port, default is the lighthouse httpRest port.
+      port: 5052
+    initialDelaySeconds: 60
+    periodSeconds: 120
+  readinessProbe:
+    tcpSocket:
+      # -- Readiness probe tcpSocket port, default is the lighthouse httpRest port.
+      port: 5052
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  # -- Resource requests and limits
+  resources: {}
+  # limits:
+      # cpu: 500m
+      # memory: 2Gi
+  # requests:
+      # cpu: 300m
+      # memory: 1Gi
+  serviceMonitor:
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 10s
+

--- a/charts/geth-lighthouse/values.yaml
+++ b/charts/geth-lighthouse/values.yaml
@@ -9,7 +9,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 global:
-  # -- Ethereum default network
+  # -- Ethereum default network. Example: mainnet, goerli, ephemery
   network: mainnet
   # -- Engine API JSON-RPC Port, see also the official [Engine Specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md)
   engineRpcPort: 8551
@@ -29,7 +29,6 @@ global:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
-  statefulSetAnnotations: {}
   updateStrategy:
     # -- Update stategy type
     type: RollingUpdate
@@ -68,10 +67,9 @@ InitContainer:
     pullPolicy: "IfNotPresent"
     # -- Image tag
     tag: "base-20221211.0.109768"
-
+    
+# If global.network=ephemery, run the [ephemery testnet](https://github.com/pk910/test-testnet-repo)
 ephemery:
-  # -- Run geth-lighthouse in the [ephemery testnet](https://github.com/pk910/test-testnet-repo)
-  enabled: false
   # -- Name of the ephemery container
   name: ephemery-init
   # -- Specify ephemery github repository

--- a/charts/lighthouse-vc/.helmignore
+++ b/charts/lighthouse-vc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lighthouse-vc/Chart.yaml
+++ b/charts/lighthouse-vc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: geth-lighthouse
-description: Helm chart that spins up a post-merge ethereum node consisting of the go-ethereum (geth) execution client and the lighthouse consensus client.
+name: lighthouse-vc
+description: Installs lighthouse in validator client mode.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.0
 
 maintainers:
   - name: laibe

--- a/charts/lighthouse-vc/README.md
+++ b/charts/lighthouse-vc/README.md
@@ -1,0 +1,83 @@
+# lighthouse-vc
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Installs lighthouse in validator client mode.
+
+## Source Code
+
+* <https://github.com/ethereum/go-ethereum>
+* <https://github.com/sigp/lighthouse>
+
+## Quick Start
+
+```shell
+# install from local copy
+helm install lighthouse-vc charts/lighthouse-vc
+```
+
+To access the beacon API, the api bearer token needs to be retrieved. By default the pod stores it under `/data/api-token.txt`, e.g. :
+
+```bash
+kubectl exec lighthouse-vc-0 -- cat /data/api-token.txt
+```
+
+Port forward for local development:
+
+```bash
+kubectl port-forward svc/lighthouse-vc 5062:5062
+# check version
+curl localhost:5062/lighthouse/version -H "Authorization: Bearer <enter-bearer-token-here>"
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| ephemery.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| ephemery.image.repository | string | `"nixery.dev/shell/gnutar/gzip/curl/jq/kubectl/gawk"` | Nixery.dev image |
+| ephemery.image.tag | string | `"latest"` | Image tag |
+| ephemery.name | string | `"ephemery-init"` | Name of the ephemery container |
+| ephemery.repository | string | `"pk910/test-testnet-repo"` | Specify ephemery github repository |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| global.affinity | object | `{}` |  |
+| global.beaconNodes | list | `["http://geth-lighthouse-node:5052"]` | List of Consenus Client (Beacon Nodes) endpoints available within cluster |
+| global.containerSecurityContext | object | `{}` |  |
+| global.imagePullSecrets | object | `{}` | A list of pull secrets is used when credentials are needed to access a container registry with username and password. |
+| global.network | string | `"mainnet"` | Ethereum default network. Example: mainnet, goerli, ephemery |
+| global.nodeSelector | object | `{}` |  |
+| global.persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
+| global.persistence.size | string | `"2Gi"` | Requested size for volume claim template. When using OpenEBS Local PV Device this ensures that a block device with sufficient storage is selected. |
+| global.persistence.storageClassName | string | `nil` | Use a specific storage class. |
+| global.podAnnotations | object | `{}` |  |
+| global.replicas | int | `1` | Replicas |
+| global.securityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | Security Context |
+| global.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| global.serviceAccount.create | bool | `true` | Enable service account (Note: Service Account will only be automatically created if `global.serviceAccount.name` is not set) |
+| global.serviceAccount.name | string | `""` | Name of an already existing service account. Setting this value disables the automatic service account creation |
+| global.statefulSetAnnotations | object | `{}` |  |
+| global.terminationGracePeriodSeconds | int | `120` |  |
+| global.tolerations | list | `[]` |  |
+| global.updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |
+| lighthouse.httpInterface | string | `"0.0.0.0"` | Specify the listen address of the lighthouse REST API server for the consensus client. |
+| lighthouse.image.pullPolicy | string | `"IfNotPresent"` |  |
+| lighthouse.image.repository | string | `"sigp/lighthouse"` | Container image repository |
+| lighthouse.image.tag | string | `"v3.2.1"` | Image tag |
+| lighthouse.livenessProbe.httpGet.path | string | `"/lighthouse/auth"` | Path for [VC endpoints](https://lighthouse-book.sigmaprime.io/api-vc-endpoints.html) NOTE: for /lighthouse/health the api token is required. |
+| lighthouse.livenessProbe.httpGet.port | int | `5062` | Liveness probe http port, default is the lighthouse httpRest port. |
+| lighthouse.livenessProbe.initialDelaySeconds | int | `5` |  |
+| lighthouse.livenessProbe.periodSeconds | int | `30` |  |
+| lighthouse.name | string | `"lighthouse"` | Name of the container |
+| lighthouse.ports.httpJson | int | `5062` | [Validator Client API](https://lighthouse-book.sigmaprime.io/api-vc.html) port |
+| lighthouse.ports.metrics | int | `6060` | Metrics ports |
+| lighthouse.ports.nodePortsStartAt | int | `31001` | VC node port starts at 31001 + #replicas (e.g. 30101 for one replica) |
+| lighthouse.readinessProbe.httpGet.path | string | `"/lighthouse/auth"` | Path for [VC endpoints](https://lighthouse-book.sigmaprime.io/api-vc-endpoints.html) NOTE: for /lighthouse/health the api token is required. |
+| lighthouse.readinessProbe.httpGet.port | int | `5062` | Readiness probe tcpSocket port, default is the lighthouse httpRest port. |
+| lighthouse.readinessProbe.initialDelaySeconds | int | `20` |  |
+| lighthouse.readinessProbe.periodSeconds | int | `30` |  |
+| lighthouse.resources | object | `{}` | Resource requests and limits |
+| lighthouse.serviceMonitor.enabled | bool | `false` |  |
+| lighthouse.serviceMonitor.interval | string | `"30s"` |  |
+| lighthouse.serviceMonitor.path | string | `"/metrics"` |  |
+| lighthouse.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
+| nameOverride | string | `""` | Overrides the chart's name |

--- a/charts/lighthouse-vc/README.md.gotmpl
+++ b/charts/lighthouse-vc/README.md.gotmpl
@@ -1,0 +1,34 @@
+{{ template "chart.header" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.sourcesSection" . }}
+{{ template "chart.requirementsSection" . }}
+
+
+## Quick Start
+
+```shell
+# install from local copy
+helm install lighthouse-vc charts/lighthouse-vc
+```
+
+To access the beacon API, the api bearer token needs to be retrieved. By default the pod stores it under `/data/api-token.txt`, e.g. :
+
+```bash
+kubectl exec lighthouse-vc-0 -- cat /data/api-token.txt
+```
+
+Port forward for local development:
+
+```bash
+kubectl port-forward svc/lighthouse-vc 5062:5062
+# check version
+curl localhost:5062/lighthouse/version -H "Authorization: Bearer <enter-bearer-token-here>"
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/lighthouse-vc/templates/_helpers.tpl
+++ b/charts/lighthouse-vc/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lighthouse-vc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lighthouse-vc.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lighthouse-vc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lighthouse-vc.labels" -}}
+helm.sh/chart: {{ include "lighthouse-vc.chart" . }}
+{{ include "lighthouse-vc.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lighthouse-vc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lighthouse-vc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lighthouse-vc.serviceAccountName" -}}
+{{- if .Values.global.serviceAccount.create }}
+{{- default (include "lighthouse-vc.fullname" .) .Values.global.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.global.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/lighthouse-vc/templates/cronjob.yaml
+++ b/charts/lighthouse-vc/templates/cronjob.yaml
@@ -1,16 +1,16 @@
 {{- if eq .Values.global.network "ephemery" }}
-# Ephemery resetter cron job that restarts the pod if there is a new ephemery itieration by querrying the GitHub API
+# ephemery resetter cron job that restarts the pod every two days
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "geth-lighthouse.fullname" . }}
+  name: {{ include "lighthouse-vc.fullname" . }}
 spec:
   schedule: "0 * * * *"
   jobTemplate:
     spec:
       template:
         spec:
-          serviceAccountName: {{ include "geth-lighthouse.serviceAccountName" . }}
+          serviceAccountName: {{ include "lighthouse-vc.serviceAccountName" . }}
           restartPolicy: Never
           containers:
           - name:  resetter
@@ -21,9 +21,9 @@ spec:
             - -c
             - >
               ITERATION_NUMBER=$(curl -s https://api.github.com/repos/{{ .Values.ephemery.repository }}/releases/latest | jq -r '.tag_name' | awk -F- '{print $2}');
-              CURRENT_ITERATION=$(kubectl get sts {{ include "geth-lighthouse.fullname" .}} -o json| jq '.metadata.annotations.iteration | tonumber');
+              CURRENT_ITERATION=$(kubectl get sts {{ include "lighthouse-vc.fullname" .}} -o json| jq '.metadata.annotations.iteration | tonumber');
               echo "current iteration: $CURRENT_ITERATION";
               echo "latest iteration: $ITERATION_NUMBER";
-              if [ $ITERATION_NUMBER -gt $CURRENT_ITERATION ]; then kubectl rollout restart sts/{{ include "geth-lighthouse.fullname" . }}; fi;
+              if [ $ITERATION_NUMBER -gt $CURRENT_ITERATION ]; then kubectl rollout restart sts/{{ include "lighthouse-vc.fullname" . }}; fi;
           restartPolicy: OnFailure
 {{- end }}

--- a/charts/lighthouse-vc/templates/role.yaml
+++ b/charts/lighthouse-vc/templates/role.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  name: {{ include "lighthouse-vc.serviceAccountName" . }}-ephemery
   labels:
-    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+    {{- include "lighthouse-vc.labels" . | nindent 4 }}
 rules:
     - apiGroups: ["apps", "extensions"]
       resources: ["statefulsets"]
       resourceNames: 
-      - "{{ include "geth-lighthouse.fullname" . }}"
+      - "{{ include "lighthouse-vc.fullname" . }}"
       verbs: ["get", "patch", "list", "watch"]
 {{- end }}

--- a/charts/lighthouse-vc/templates/rolebinding.yaml
+++ b/charts/lighthouse-vc/templates/rolebinding.yaml
@@ -2,15 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  name: {{ include "lighthouse-vc.serviceAccountName" . }}-ephemery
   labels:
-    {{- include "geth-lighthouse.labels" . | nindent 4 }}
+    {{- include "lighthouse-vc.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "geth-lighthouse.serviceAccountName" . }}
+  name: {{ include "lighthouse-vc.serviceAccountName" . }}-ephemery
 subjects:
   - kind: ServiceAccount
-    name: {{ include "geth-lighthouse.serviceAccountName" . }}
+    name: {{ include "lighthouse-vc.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
+

--- a/charts/lighthouse-vc/templates/service-headless.yaml
+++ b/charts/lighthouse-vc/templates/service-headless.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lighthouse-vc.fullname" . }}-headless
+  labels:
+    {{- include "lighthouse-vc.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.lighthouse.ports.httpJson }}
+      targetPort: {{ .Values.lighthouse.ports.httpJson }}
+      protocol: TCP
+      name: lh-vc-http-json
+    - port: {{ .Values.lighthouse.ports.metrics }}
+      targetPort: {{ .Values.lighthouse.ports.metrics }}
+      protocol: TCP
+      name: lh-vc-metrics
+  selector:
+    {{- include "lighthouse-vc.selectorLabels" . | nindent 4 }}

--- a/charts/lighthouse-vc/templates/service-nodeport.yaml
+++ b/charts/lighthouse-vc/templates/service-nodeport.yaml
@@ -1,0 +1,28 @@
+{{- range $i, $e := until (int $.Values.global.replicas) }}
+{{- $rangeItem := . -}}
+{{- with $ }}
+{{- $port := add $.Values.lighthouse.ports.nodePortsStartAt $i }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lighthouse-vc.fullname" . }}-nodeport-{{ $i }}
+  labels:
+    {{- include "lighthouse-vc.labels" $ | nindent 4 }}
+    pod: {{ include "lighthouse-vc.fullname" $ }}-{{ $i }}
+    type: lh-vc-http
+spec:
+  type: NodePort
+  externalTrafficPolicy: Cluster
+  ports:
+    - port: {{ .Values.lighthouse.ports.httpJson}}
+      targetPort: lh-vc-http
+      nodePort: {{ $port }}
+      protocol: TCP
+      name: lh-vc-http
+  selector:
+    {{- include "lighthouse-vc.selectorLabels" . | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ include "lighthouse-vc.fullname" $ }}-{{ $i }}
+  
+{{- end }}
+{{- end }}

--- a/charts/lighthouse-vc/templates/service.yaml
+++ b/charts/lighthouse-vc/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lighthouse-vc.fullname" . }}
+  labels:
+    {{- include "lighthouse-vc.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.lighthouse.ports.httpJson }}
+      targetPort: {{ .Values.lighthouse.ports.httpJson }}
+      protocol: TCP
+      name: lh-vc-http-json
+    - port: {{ .Values.lighthouse.ports.metrics }}
+      targetPort: {{ .Values.lighthouse.ports.metrics }}
+      protocol: TCP
+      name: lh-vc-metrics
+  selector:
+    {{- include "lighthouse-vc.selectorLabels" . | nindent 4 }}

--- a/charts/lighthouse-vc/templates/serviceaccount.yaml
+++ b/charts/lighthouse-vc/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.global.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lighthouse-vc.serviceAccountName" . }}
+  labels:
+    {{- include "lighthouse-vc.labels" . | nindent 4 }}
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lighthouse-vc/templates/servicemonitor.yaml
+++ b/charts/lighthouse-vc/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.lighthouse.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lighthouse-vc.serviceAccountName" . }}
+  labels:
+    {{- include "lighthouse-vc.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  # lighthouse
+  - interval: {{ .Values.lighthouse.serviceMonitor.interval }}
+    {{- if .Values.lighthouse.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.lighthouse.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: lh-vc-metrics
+    path: {{ .Values.lighthouse.serviceMonitor.path }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "lighthouse-vc.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/lighthouse-vc/templates/statefulset.yaml
+++ b/charts/lighthouse-vc/templates/statefulset.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "lighthouse-vc.fullname" . }}
+  labels:
+    {{- include "lighthouse-vc.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.global.statefulSetAnnotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.global.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lighthouse-vc.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "lighthouse-vc.fullname" . }}-headless
+  updateStrategy:
+    {{- toYaml .Values.global.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lighthouse-vc.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lighthouse-vc.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.global.securityContext | nindent 8 }}
+      initContainers:
+        {{- if eq .Values.global.network "ephemery" }}
+        # ephemery init container
+        - name: ephemery-init
+          image: "{{ .Values.ephemery.image.repository }}:{{ .Values.ephemery.image.tag }}"
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          imagePullPolicy: {{ .Values.ephemery.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              chown -R 1001:1001 /data;
+              rm -rf /data/ephemery;
+              mkdir -p /data/ephemery && cd /data/ephemery;
+              RELEASE=$(curl -s https://api.github.com/repos/{{ .Values.ephemery.repository }}/releases/latest | jq -r '.tag_name');
+              ITERATION=$(echo $RELEASE|awk -F- '{print $2}');
+              kubectl annotate --overwrite sts {{ include "lighthouse-vc.fullname" . }} iteration=$ITERATION;
+              curl -s -L https://github.com/{{ .Values.ephemery.repository }}/releases/download/$RELEASE/testnet-all.tar.gz > testnet-all.tar.gz;
+              tar xzvf testnet-all.tar.gz;
+              cat config.yaml;
+              rm -f /data/slashing_protection.sqlite;
+              rm -f /data/slashing_protection.sqlite-journal;
+          volumeMounts:
+            - name: storage
+              mountPath: "/data"
+         {{- end }}
+      containers:
+        # Lighthouse validator client container
+        - name: {{ .Values.lighthouse.name }}
+          securityContext: 
+           {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.lighthouse.image.repository }}:{{ .Values.lighthouse.image.tag }}"
+          imagePullPolicy: {{ .Values.lighthouse.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              exec lighthouse
+              {{- if eq .Values.global.network "ephemery" }}
+              --testnet-dir=/data/ephemery/
+              {{- else }}
+              --network={{ .Values.global.network }}
+              {{- end }}
+              vc
+              --beacon-nodes {{ join "," .Values.global.beaconNodes }} 
+              --validators-dir=/data
+              --secrets-dir=/data
+              --http 
+              --http-address={{ .Values.lighthouse.httpInterface }}
+              --http-port={{ .Values.lighthouse.ports.httpJson }}
+              --unencrypted-http-transport
+              --http-allow-origin=*
+              --metrics
+              --metrics-allow-origin=*
+              --metrics-address=0.0.0.0
+              --metrics-port="{{ .Values.lighthouse.ports.metrics }}"
+          volumeMounts:
+            - name: storage
+              mountPath: "/data"
+            {{- if eq .Values.global.network "ephemery" }}
+            - name: storage
+              mountPath: "/data/ephemery"
+              subPath: ephemery
+              readOnly: true
+            {{- end }}
+          ports:
+            - name: lh-vc-http
+              containerPort: {{ .Values.lighthouse.ports.httpJson }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.lighthouse.ports.metrics }}
+          livenessProbe:
+            {{- toYaml .Values.lighthouse.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.lighthouse.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.lighthouse.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.global.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.global.terminationGracePeriodSeconds }}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+    spec:
+      accessModes:
+        {{- toYaml .Values.global.persistence.accessModes | nindent 8 }}
+      storageClassName: {{ .Values.global.persistence.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.global.persistence.size }}
+
+

--- a/charts/lighthouse-vc/values.yaml
+++ b/charts/lighthouse-vc/values.yaml
@@ -1,0 +1,122 @@
+# Default values for lighthouse validator client.
+# This is a YAML-formatted file.
+
+# -- Overrides the chart's name
+nameOverride: ""
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+global:
+  # -- Ethereum default network. Example: mainnet, goerli, ephemery
+  network: mainnet
+  # -- List of Consenus Client (Beacon Nodes) endpoints available within cluster
+  beaconNodes: 
+    - http://geth-lighthouse-node:5052
+  # -- Replicas
+  replicas: 1
+  # -- A list of pull secrets is used when credentials are needed to access a container registry with username and password.
+  imagePullSecrets: {}
+  podAnnotations: {}
+  # -- Security Context
+  securityContext:
+    fsGroup: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    runAsUser: 1001
+  containerSecurityContext: {}
+    #capabilities:
+    #  drop:
+    #    - ALL
+    #allowPrivilegeEscalation: false
+    #seccompProfile:
+    #  type: RuntimeDefault
+  statefulSetAnnotations: {}
+  updateStrategy:
+    # -- Update stategy type
+    type: RollingUpdate
+  terminationGracePeriodSeconds: 120
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # PVC settings 
+  persistence:
+    # -- Access mode for the volume claim template
+    accessModes:
+    - ReadWriteOnce
+    # -- Requested size for volume claim template. When using OpenEBS Local PV Device this ensures that a block device with sufficient storage is selected.
+    size: 2Gi
+    # -- Use a specific storage class.
+    storageClassName: null
+  serviceAccount:
+    # -- Enable service account (Note: Service Account will only be automatically created if `global.serviceAccount.name` is not set)
+    create: true
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- Name of an already existing service account. Setting this value disables the automatic service account creation
+    name: ""
+
+# ephemery testnet
+ephemery:
+  # -- Name of the ephemery container
+  name: ephemery-init
+  # -- Specify ephemery github repository
+  repository: pk910/test-testnet-repo
+  image:
+    # -- Nixery.dev image
+    repository: "nixery.dev/shell/gnutar/gzip/curl/jq/kubectl/gawk"
+    # -- Container pull policy
+    pullPolicy: "IfNotPresent"
+    # -- Image tag
+    tag: latest
+
+# Lighthouse Validator Client values
+lighthouse:
+  # -- Name of the container
+  name: "lighthouse"
+  image:
+    # -- Container image repository
+    repository: "sigp/lighthouse"
+    pullPolicy: "IfNotPresent"
+    # -- Image tag
+    tag: v3.2.1
+  ports:
+    # -- [Validator Client API](https://lighthouse-book.sigmaprime.io/api-vc.html) port
+    httpJson: 5062
+    # -- VC node port starts at 31001 + #replicas (e.g. 30101 for one replica)
+    nodePortsStartAt: 31001
+    # -- Metrics ports
+    metrics: 6060
+  # -- Specify the listen address of the lighthouse REST API server for the consensus client.
+  httpInterface: "0.0.0.0"
+  # 200 : VC is healthy
+  livenessProbe:
+    httpGet:
+      # -- Path for [VC endpoints](https://lighthouse-book.sigmaprime.io/api-vc-endpoints.html)
+      # NOTE: for /lighthouse/health the api token is required.
+      path: /lighthouse/auth
+      # -- Liveness probe http port, default is the lighthouse httpRest port.
+      port: 5062
+    initialDelaySeconds: 5
+    periodSeconds: 30
+  readinessProbe:
+    httpGet:
+      # -- Path for [VC endpoints](https://lighthouse-book.sigmaprime.io/api-vc-endpoints.html)
+      # NOTE: for /lighthouse/health the api token is required.
+      path: /lighthouse/auth
+      # -- Readiness probe tcpSocket port, default is the lighthouse httpRest port.
+      port: 5062
+    initialDelaySeconds: 20
+    periodSeconds: 30
+  # -- Resource requests and limits
+  resources: {}
+  # limits:
+      # cpu: 500m
+      # memory: 2Gi
+  # requests:
+  #   cpu: 2000m
+  #   memory: 4Gi
+  serviceMonitor:
+    enabled: false
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 10s


### PR DESCRIPTION
Adds a helm chart for the geth-lighthouse client pair with support for the Ephemeral testnet.
