### PR TITLE
Adding link to 2nd manual install script (geth-lodestar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ If you simply want to run a node on Ephemery, you can manually set this up by fo
 
 Warning: you will need to manually reset your system when the testnet is reset.
 
+- [geth + lodestar](./manual/setup-geth-lodestar.md)
 - [geth + teku](./manual/setup-geku.md)


### PR DESCRIPTION
For some time, the only instructions to manually "run your own node" on Ephemery were for the geth-teku client combination ("geku"). These need to be either updated or retired, in favour of more recent contributions.

Further to the contribution of `setup-geth-lodestar.md` by @atkinsonholly this PR adds a link to these instructions from the "main ephemery onboarding flow", making them the primary route for running your own node on Ephemery.