### PR TITLE
Significant retention.sh Update

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,7 @@ TESTNET_DIR=/etc/ephemery
 EL_CLIENT=nethermind
 EL_SERVICE=execution
 EL_DATADIR=/var/lib/ethereum/nethermind
+EL_USER=execution
 
 CL_CLIENT=prysm
 CL_SERVICE=consensus
@@ -13,8 +14,8 @@ VC_CLIENT=lodestar
 VC_SERVICE=validator
 VC_DATADIR=/var/lib/ethereum/lodestar-validator
 
-EPHEMERY_FILES_USER=ethereum
-EPHEMERY_FILES_GROUP=ethereum
+TESTNET_FILES_USER=ethereum
+TESTNET_FILES_GROUP=ethereum
 
 # Set FORCE_RESET to 1 to test reset process
 #FORCE_RESET=1

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,20 @@
+TESTNET_DIR=/etc/ephemery
+
+EL_CLIENT=nethermind
+EL_SERVICE=execution
+EL_DATADIR=/var/lib/ethereum/nethermind
+
+CL_CLIENT=prysm
+CL_SERVICE=consensus
+CL_DATADIR=/var/lib/ethereum/prysm-beacon
+CL_PORT=3500
+
+VC_CLIENT=lodestar
+VC_SERVICE=validator
+VC_DATADIR=/var/lib/ethereum/lodestar-validator
+
+EPHEMERY_FILES_USER=ethereum
+EPHEMERY_FILES_GROUP=ethereum
+
+# Set FORCE_RESET to 1 to test reset process
+#FORCE_RESET=1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,26 @@ Running a node in this test network requires resetting clients with a new genesi
 
 ## Retention script
 
-Script `retention.sh` provides the main mechanism for resetting the network. It checks for period timeout and resets the node automatically. Make sure to read the script first, modify variables and paths to match your setup. 
+Script `retention.sh` provides the main mechanism for resetting the network. It checks for period timeout and resets the node automatically. Configure your script using a file containing the following environment variables, and pass that file as the first argument to `retention.sh`.
+
+- TESTNET_DIR - Path to the directory in which Ephemery testnet files are stored
+- EL_CLIENT - Type of execution client, lower case: geth, nethermind, besu, erigon, or reth
+- EL_SERVICE - Name of the execution client systemd service to start/stop
+- EL_DATADIR - Data directory of the execution client
+- CL_CLIENT - Type of consensus client, lower case: prysm, lighthouse, nimbus, teku or lodestar
+- CL_SERVICE - Name of the consensus client systemd service to start/stop
+- CL_DATADIR - Data directory of consensus client
+- CL_PORT - JSON RPC port of consensus client. Default: `3500`
+- VC_CLIENT - **Optional:** Type of validator client, lower case: prysm, lighthouse, nimbus, teku or lodestar. Leave unset if using single-process consensus/validator client.
+- VC_SERVICE - **Optional:** Name of the validator client systemd service to start/stop. Leave unset if using single-process consensus/validator client.
+- VC_DATADIR - **Optional:** Data directory of validator client. Leave unset if using single-process consensus/validator client.
+- EPHEMERY_FILES_USER - **Optional:** User to which Ephemery testnet directory and files should be assigned. By default file ownership will be left unchanged.
+- EPHEMERY_FILES_GROUP - **Optional:** Group to which Ephemery testnet directory and files should be assigned. By default the group will be left unchanged.
+- FORCE_RESET - **Optional:** Set to `1` to force reset of testnet files and clients for testing purposes. Default: `0`
+
+See `.env.sample` for an example of setting the environment variables. Run `retention.sh .env` to use values set in `.env` environment variables file.
+
+Default values for all environment variables may also be set within the script and the script can be run as `retention.sh`.
 
 By default, the script is controlling clients using their systemd services. You can find examples files for services in `systemd-services` directory, you should also modify them to suit your system.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Script `retention.sh` provides the main mechanism for resetting the network. It 
 - EL_CLIENT - Type of execution client, lower case: geth, nethermind, besu, erigon, or reth
 - EL_SERVICE - Name of the execution client systemd service to start/stop
 - EL_DATADIR - Data directory of the execution client
+- EL_USER - **Optional:** Username that the genesis initialization should be run for the execution clients. Runs as script user if not assigned
 - CL_CLIENT - Type of consensus client, lower case: prysm, lighthouse, nimbus, teku or lodestar
 - CL_SERVICE - Name of the consensus client systemd service to start/stop
 - CL_DATADIR - Data directory of consensus client
@@ -19,8 +20,8 @@ Script `retention.sh` provides the main mechanism for resetting the network. It 
 - VC_CLIENT - **Optional:** Type of validator client, lower case: prysm, lighthouse, nimbus, teku or lodestar. Leave unset if using single-process consensus/validator client.
 - VC_SERVICE - **Optional:** Name of the validator client systemd service to start/stop. Leave unset if using single-process consensus/validator client.
 - VC_DATADIR - **Optional:** Data directory of validator client. Leave unset if using single-process consensus/validator client.
-- EPHEMERY_FILES_USER - **Optional:** User to which Ephemery testnet directory and files should be assigned. By default file ownership will be left unchanged.
-- EPHEMERY_FILES_GROUP - **Optional:** Group to which Ephemery testnet directory and files should be assigned. By default the group will be left unchanged.
+- TESTNET_FILES_USER - **Optional:** User to which testnet directory and files should be assigned. By default file ownership will be left unchanged.
+- TESTNET_FILES_GROUP - **Optional:** Group to which testnet directory and files should be assigned. By default the group will be left unchanged.
 - FORCE_RESET - **Optional:** Set to `1` to force reset of testnet files and clients for testing purposes. Default: `0`
 
 See `.env.sample` for an example of setting the environment variables. Run `retention.sh .env` to use values set in `.env` environment variables file.

--- a/retention.sh
+++ b/retention.sh
@@ -265,7 +265,7 @@ clear_consensus_datadir() {
 
 clear_validator_datadir() {
  
-  if [ -n "$vc_client" ]; then
+  if [ -z "$vc_client" ]; then
     log "Validator client undefined."
     return
   fi

--- a/retention.sh
+++ b/retention.sh
@@ -236,10 +236,10 @@ clear_consensus_datadir() {
       fi
 
       # Clear slashing_protection.sqlite
-      if [ -f "$cl_datadir/keys/slashing_protection.sqlite" ]; then
-        rm_cmd=("rm" "-rf" "$cl_datadir/keys/slashing_protection.sqlite")
+      if [ -f "$cl_datadir/validators/slashing_protection.sqlite" ]; then
+        rm_cmd=("rm" "-rf" "$cl_datadir/validators/slashing_protection.sqlite")
         "${rm_cmd[@]}"
-        log "Deleted $cl_datadir/keys/slashing_protection.sqlite for $cl_client consensus client"
+        log "Deleted $cl_datadir/validators/slashing_protection.sqlite for $cl_client consensus client"
       fi
       ;;
 
@@ -333,10 +333,10 @@ clear_validator_datadir() {
       ;;
 
     "lighthouse")
-      if [ -f "$vc_datadir/keys/slashing_protection.sqlite" ]; then
-        rm_cmd=("rm" "-rf" "$vc_datadir/keys/slashing_protection.sqlite")
+      if [ -f "$vc_datadir/validators/slashing_protection.sqlite" ]; then
+        rm_cmd=("rm" "-rf" "$vc_datadir/validators/slashing_protection.sqlite")
         "${rm_cmd[@]}"
-        log "Deleted $vc_datadir/keys/slashing_protection.sqlite for $vc_client validator client"
+        log "Deleted $vc_datadir/validators/slashing_protection.sqlite for $vc_client validator client"
       fi
       ;;
 

--- a/retention.sh
+++ b/retention.sh
@@ -414,11 +414,11 @@ download_genesis_release() {
 
 reset_testnet() { 
 
-  stop_client($el_service)
-  stop_client($cl_service)
+  stop_client $el_service
+  stop_client $cl_service
 
   if [ -n "$vc_service" ]; then
-    stop_client($vc_service)
+    stop_client $vc_service
   fi
 
   clear_execution_datadir
@@ -429,11 +429,11 @@ reset_testnet() {
 
   if [ -n "$vc_service" ]; then
     clear_validator_datadir
-    start_client($vc_service)
+    start_client $vc_service
   fi
 
-  start_client($el_service)
-  start_client($cl_service)
+  start_client $el_service
+  start_client $cl_service
 }
 
 

--- a/retention.sh
+++ b/retention.sh
@@ -1,43 +1,257 @@
 #!/bin/bash
 
-genesis_repository="ephemery-testnet/ephemery-genesis"
-testnet_dir=/home/ethereum/testnet
-el_datadir=/home/ethereum/data-geth
-cl_datadir=/home/ethereum/data-lh
-cl_port=5052
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
 
+# Check if an environment file is provided as the first argument
+if [[ -n "$1" ]]; then
+  ENV_FILE="$1"
+  # Check if the specified environment file exists and source it
+  if [[ -f "$ENV_FILE" ]]; then
+    log "Loading environment variables from $ENV_FILE"
+    source "$ENV_FILE"
+  else
+    log "Environment file '$ENV_FILE' not found."
+    exit 1
+  fi
+else
+  log "No environment file provided. Using default values."
+fi
+
+genesis_repository="ephemery-testnet/ephemery-genesis"
+timeout_window=600
+
+## Defaults can be set here or use environment variables to override defaults
+
+default_testnet_dir=
+
+# execution
+default_el_client=
+default_el_service=
+default_el_datadir=
+
+# consensus
+default_cl_client=
+default_cl_service=
+default_cl_datadir=
+default_cl_port=3500
+
+# validator
+default_vc_client=
+default_vc_service=
+default_vc_datadir=
+
+# Ephemery Ownership
+default_ephemery_files_user=
+default_ephemery_files_group=
+
+## Read environment variables, if present
+
+testnet_dir=${TESTNET_DIR:-$default_testnet_dir}
+
+el_client=${EL_CLIENT:-$default_el_client}
+el_service=${EL_SERVICE:-$default_el_service}
+el_datadir=${EL_DATADIR:-$default_el_datadir}
+
+cl_client=${CL_CLIENT:-$default_cl_client}
+cl_service=${CL_SERVICE:-$default_cl_service}
+cl_datadir=${CL_DATADIR:-$default_cl_datadir}
+cl_port=${CL_PORT:-$default_cl_port}
+
+vc_client=${VC_CLIENT:-$default_vc_client}
+vc_service=${VC_SERVICE:-$default_vc_service}
+vc_datadir=${VC_DATADIR:-$default_vc_datadir}
+
+ephemery_files_user=${EPHEMERY_FILES_USER:-$default_ephemery_files_user}
+ephemery_files_group=${EPHEMERY_FILES_GROUP:-$default_ephemery_files_group}
+
+# Set FORCE_RESET environment variable to 1 test reset
+force_reset="${FORCE_RESET:-0}"
 
 start_clients() {
-  # start EL / CL clients
-  echo "start clients"
-  sudo /bin/systemctl start geth
-  sudo /bin/systemctl start beacon-chain
-  sudo /bin/systemctl start validator
+  # start clients
+  log "Starting $cl_service and $el_service services"
+  /bin/systemctl start $cl_service
+  /bin/systemctl start $el_service
+
+  if [ -n "$vc_service" ]; then
+    log "Starting $vc_service service"
+    /bin/systemctl start $vc_service
+  fi
 }
 
 stop_clients() {
-  # stop EL / CL clients
-  echo "stop clients"
-  sudo /bin/systemctl stop geth
-  sudo /bin/systemctl stop beacon-chain
-  sudo /bin/systemctl stop validator
+  # stop clients
+  log "Stopping $cl_service and $el_service systemd services"
+  /bin/systemctl stop $cl_service
+  /bin/systemctl stop $el_service
+
+  if [ -n "$vc_service" ]; then
+    log "Stopping $vc_service service"
+    /bin/systemctl stop $vc_service
+  fi
 }
 
-clear_datadirs() {
-  if [ -d $el_datadir/geth ]; then
-    geth_nodekey=$(cat $el_datadir/geth/nodekey)
-    rm -rf $el_datadir/geth
-    mkdir $el_datadir/geth
-    echo $geth_nodekey > $el_datadir/geth/nodekey
-  fi
+clear_execution_datadir() {
+  case "$el_client" in
+    "geth")
+      # Delete everything in $cl_datadir/geth/* except for nodekey
+      if [ -d "$el_datadir/geth" ]; then
+        find "$el_datadir/geth" -mindepth 1 -maxdepth 1 ! -name 'nodekey' -exec rm -rf {} +
+        log "Retained nodekey file in $el_datadir and deleted other contents for $el_client execution client"
+      fi
+      ;;
 
-  rm -rf $cl_datadir/beacon
-  rm -rf $cl_datadir/validators/slashing_protection.sqlite
+    "erigon")
+      if [ -d "$el_datadir" ]; then
+        find "$el_datadir" ! -name 'config.json' ! -name 'customGenesis.json' -type f -delete
+        log "Retained config.json and customGenesis.json files in $el_datadir and deleted other contents for $el_client execution client"
+      fi
+      ;;
+
+    *)
+      if [ -d "$el_datadir" ]; then
+        rm -rf "$el_datadir"/*
+        log "Deleted contents of $el_datadir/ for $el_client execution client"
+      fi
+      ;;
+  esac
+}
+
+clear_consensus_datadir() {
+  case "$cl_client" in
+    "teku")
+      # Delete everything in $cl_datadir/beacon/* except for kvstore
+      if [ -d "$cl_datadir/beacon" ]; then
+        find "$cl_datadir/beacon" -mindepth 1 -maxdepth 1 ! -name 'kvstore' -exec rm -rf {} +
+        log "Retained kvstore file in $cl_datadir/beacon and deleted other contents for $cl_client consensus client"
+      fi
+
+      # Delete logs if present
+      if [ -d "$cl_datadir/logs" ]; then
+        rm -rf "$cl_datadir/logs"/*
+        log "Deleted contents of $cl_datadir/logs for $cl_client consensus client"
+      fi
+
+      # Delete slashprotection/slashprotection.sqlite if present
+      # Captures validator requirements if using single process
+      if [ -f "$cl_datadir/slashprotection/slashprotection.sqlite" ]; then
+        rm -rf "$cl_datadir/slashprotection/slashprotection.sqlite"
+        log "Deleted $cl_datadir/slashprotection/slashprotection.sqlite for $cl_client consensus client"
+      fi
+      ;;
+
+    "lighthouse")
+      # Delete everything in $cl_datadir/beacon/* except for network
+      if [ -d "$cl_datadir/beacon" ]; then
+        find "$cl_datadir/beacon" -mindepth 1 -maxdepth 1 ! -name 'network' -exec rm -rf {} +
+        log "Retained network file in $cl_datadir/beacon and deleted other contents for $cl_client consensus client"
+      fi
+
+      # Delete keys/slashing_protection.sqlite
+      # Captures validator requirements if using single process
+      if [ -f $cl_datadir/keys/slashing_protection.sqlite ]; then
+        rm -rf $cl_datadir/keys/slashing_protection.sqlite
+        log "Deleted contents of $cl_datadir/keys/slashing_protection.sqlite for $cl_client consensus client"
+      fi
+      ;;
+
+    "lodestar")
+      # Delete chaindb if present
+      if [ -d "$cl_datadir/chain-db" ]; then
+        rm -rf "$cl_datadir/chain-db"/*
+        log "Deleted contents of $cl_datadir/chain-db for $cl_client consensus client"
+      fi
+
+      # Delete validator-db directory if present
+      # Captures validator requirements if using single process
+      if [ -d "$cl_datadir/validator-db" ]; then
+        rm -rf "$cl_datadir/validator-db"/*
+        log "Deleted contents of $cl_datadir/validator-db for $cl_client consensus client"
+      fi
+      ;;
+
+    "nimbus")
+      rm -rf "$cl_datadir"/*
+      log "Deleted contents of $cl_datadir data directory for $cl_client consensus client"
+
+      # Delete validators/slashing_protection.sqlite3
+      # Captures validator requirements if using single process
+      if [ -f $vc_datadir/validators/slashing_protection.sqlite3 ]; then
+        rm -rf $vc_datadir/validators/slashing_protection.sqlite3
+        log "Deleted $vc_datadir/validators/slashing_protection.sqlite3 for $cl_client consensus client"
+      fi
+      ;;
+
+    "prysm")
+      rm -rf "$cl_datadir"/*
+      log "Deleted contents of $cl_datadir data directory for $cl_client consensus client"
+
+      # Delete prysm-wallet-v2/direct/validator.db
+      # Captures validator requirements if using single process
+      if [ -f $vc_datadir/prysm-wallet-v2/direct/validator.db ]; then
+        rm -rf $vc_datadir/prysm-wallet-v2/direct/validator.db
+        log "Deleted $vc_datadir/prysm-wallet-v2/direct/validator.db for $cl_client consensus client"
+      fi
+      ;;
+  esac
+}
+
+clear_validator_datadir() {
+  if [ -n "$vc_service" ] && [ -n "$vc_client" ] && [ -n "$vc_datadir" ]; then
+    case "$vc_client" in
+      "prysm")
+        if [ -f $vc_datadir/prysm-wallet-v2/direct/validator.db ]; then
+          rm -rf $vc_datadir/prysm-wallet-v2/direct/validator.db
+          log "Deleted $vc_datadir/prysm-wallet-v2/direct/validator.db for $vc_client validator client"
+        fi
+        ;;
+
+      "teku")
+        if [ -f $vc_datadir/slashprotection/slashprotection.sqlite ]; then
+          rm -rf $vc_datadir/slashprotection/slashprotection.sqlite
+          log "Deleted $vc_datadir/slashprotection/slashprotection.sqlite for $vc_client validator client"
+        fi
+        ;;
+
+      "nimbus")
+        if [ -f $vc_datadir/validators/slashing_protection.sqlite3 ]; then
+          rm -rf $vc_datadir/validators/slashing_protection.sqlite3
+          log "Deleted $vc_datadir/validators/slashing_protection.sqlite3 for $vc_client validator client"
+        fi
+        ;;
+
+      "lighthouse")
+        if [ -f $vc_datadir/keys/slashing_protection.sqlite ]; then
+          rm -rf $vc_datadir/keys/slashing_protection.sqlite
+          log "Deleted $vc_datadir/keys/slashing_protection.sqlite for $vc_client validator client"
+        fi
+        ;;
+
+      "lodestar")
+        # Delete validator-db if present
+        if [ -d "$vc_datadir/validator-db" ]; then
+          rm -rf "$vc_datadir/validator-db"/*
+          log "Deleted contents of $vc_datadir/validator-db/ for $vc_client validator client"
+        fi
+        ;;
+    esac
+  fi
 }
 
 setup_genesis() {
-  # init el genesis
-  ~/geth/bin/geth init --datadir $el_datadir $testnet_dir/genesis.json
+  case "$el_client" in
+    "geth")
+      log "Initializing geth genesis"
+      geth init --datadir $el_datadir $testnet_dir/genesis.json
+      ;;
+
+    "erigon")
+      log "Initializing erigon genesis"
+      erigon init --datadir $el_datadir $testnet_dir/genesis.json
+      ;;
+  esac
 }
 
 get_github_release() {
@@ -53,17 +267,28 @@ download_genesis_release() {
   # remove old genesis
   if [ -d $testnet_dir ]; then
     rm -rf $testnet_dir/*
+    log "Removed existing files from testnet directory $testnet_dir"
   else
     mkdir -p $testnet_dir
+    log "Created testnet directory $testnet_dir"
   fi
 
   # get latest genesis
-  wget -qO- https://github.com/$genesis_repository/releases/download/$genesis_release/testnet-all.tar.gz | tar xvz -C $testnet_dir
+  log "Getting latest genesis files and unpacking into $testnet_dir"
+  wget -qO- https://github.com/$genesis_repository/releases/download/$genesis_release/testnet-all.tar.gz | tar xvz -C $testnet_dir > /dev/null 2>&1
+
+  # Reset ephemery file ownership if we have a username and group
+  if [ -n "$ephemery_files_user" ] && [ -n "$ephemery_files_group" ]; then
+    chown -R $ephemery_files_user:$ephemery_files_group $testnet_dir
+    log "Reset ownership and group of Ephemery genesis files in $testnet_dir to $ephemery_files_user:$ephemery_files_group"
+  fi
 }
 
 reset_testnet() {
   stop_clients
-  clear_datadirs
+  clear_consensus_datadir
+  clear_execution_datadir
+  clear_validator_datadir
   download_genesis_release $1
   setup_genesis
   start_clients
@@ -71,41 +296,47 @@ reset_testnet() {
 
 check_testnet() {
   current_time=$(date +%s)
-  genesis_time=$(curl -s http://localhost:$cl_port/eth/v1/beacon/genesis | sed 's/.*"genesis_time":"\{0,1\}\([^,"]*\)"\{0,1\}.*/\1/')
+  genesis_time=$(curl -s http://127.0.0.1:$cl_port/eth/v1/beacon/genesis | sed 's/.*"genesis_time":"\{0,1\}\([^,"]*\)"\{0,1\}.*/\1/')
   if ! [ $genesis_time -gt 0 ]; then
-    echo "could not get genesis time from beacon node"
+    log "Could not get genesis time from beacon node"
     return 0
   fi
 
   if ! [ -f $testnet_dir/retention.vars ]; then
-    echo "could not find retention.vars"
+    log "Could not find retention.vars"
     return 0
   fi
   source $testnet_dir/retention.vars
 
-  testnet_timeout=$(expr $genesis_time + $GENESIS_RESET_INTERVAL - 300)
-  echo "genesis timeout: $(expr $testnet_timeout - $current_time) sec"
+  testnet_timeout=$(expr $genesis_time + $GENESIS_RESET_INTERVAL - $timeout_window)
+  log "Genesis timeout: $(expr $testnet_timeout - $current_time) sec (timeout at $(date -d @$testnet_timeout '+%Y-%m-%d %H:%M:%S'))"
   if [ $testnet_timeout -le $current_time ]; then
     genesis_release=$(get_github_release $genesis_repository)
     if ! [ $ITERATION_RELEASE ]; then
       ITERATION_RELEASE=$CHAIN_ID
     fi
+
     if [ $genesis_release = $ITERATION_RELEASE ]; then
-      echo "could not find new genesis release (release: $genesis_release)"
+      log "Could not find new genesis release (release: $genesis_release)"
       return 0
     fi
-    
+
     reset_testnet $genesis_release
   fi
 }
 
 main() {
-  if ! [ -f $testnet_dir/genesis.json ]; then
-    reset_testnet $(get_github_release $genesis_repository)
+  if [[ "$force_reset" -eq 1 ]]; then
+    log "Forced reset by user"
+    reset_testnet "$(get_github_release "$genesis_repository")"
   else
-    check_testnet
+    if ! [ -f $testnet_dir/genesis.json ]; then
+      log "File genesis.json not found, resetting"
+      reset_testnet "$(get_github_release "$genesis_repository")"
+    else
+      check_testnet
+    fi
   fi
-
 }
 
 main

--- a/retention.sh
+++ b/retention.sh
@@ -52,7 +52,7 @@ if [[ -n "$1" ]]; then
     exit 1
   fi
 else
-  log "No environment file provided. Using default values."
+  log "No environment file provided. Using existing environment variables or default values."
 fi
 
 genesis_repository="ephemery-testnet/ephemery-genesis"

--- a/retention.sh
+++ b/retention.sh
@@ -69,6 +69,21 @@ ephemery_files_group=${EPHEMERY_FILES_GROUP:-$default_ephemery_files_group}
 # Set FORCE_RESET environment variable to 1 test reset
 force_reset="${FORCE_RESET:-0}"
 
+# Collect missing variables into an array
+missing_vars=()
+for var_name in "testnet_dir" "el_client" "el_service" "el_datadir" \
+                "cl_client" "cl_service" "cl_datadir"; do
+  if [[ -z "${!var_name}" ]]; then
+    missing_vars+=("$var_name")
+  fi
+done
+
+# Exit if any required variables are missing
+if [[ ${#missing_vars[@]} -gt 0 ]]; then
+  log "Error: The following required variables are missing or empty: ${missing_vars[*]}"
+  exit 1
+fi
+
 start_clients() {
   # start clients
   log "Starting $cl_service and $el_service services"
@@ -173,8 +188,10 @@ clear_consensus_datadir() {
       ;;
 
     "nimbus")
-      rm -rf "$cl_datadir"/*
-      log "Deleted contents of $cl_datadir data directory for $cl_client consensus client"
+      if [ -d "$cl_datadir" ]; then
+        rm -rf "$cl_datadir"/*
+        log "Deleted contents of $cl_datadir data directory for $cl_client consensus client"
+      fi
 
       # Delete validators/slashing_protection.sqlite3
       # Captures validator requirements if using single process
@@ -185,8 +202,10 @@ clear_consensus_datadir() {
       ;;
 
     "prysm")
-      rm -rf "$cl_datadir"/*
-      log "Deleted contents of $cl_datadir data directory for $cl_client consensus client"
+      if [ -d "$cl_datadir" ]; then
+        rm -rf "$cl_datadir"/*
+        log "Deleted contents of $cl_datadir data directory for $cl_client consensus client"
+      fi
 
       # Delete prysm-wallet-v2/direct/validator.db
       # Captures validator requirements if using single process


### PR DESCRIPTION
Major retention.sh update to generalize functionality, add configurability, improve error checking, add more client support, etc.

- Retained ability to set default value of variables in the script, but now also supports environment variables and loading an environment variable file
- Added timeout_window variable to configure timeout for resetting clients
- Client systemd service names must now be defined to support different system setups
- Client type must be defined for each client to support different logic for various clients
- Ownership and group of testnet files can now be reset after downloaded latest files, in case specific ownership is required
- FORCE_RESET option added to force a reset of the clients for testing purposes
- Additional error checking around parameters
- External command calls updated to avoid injections into commands
- Execution data directory logic now retains enode info for reth, geth, besu, nethermind and erigon
- Logic updated to support single-client consensus/validator clients or separate consensus and validator clients
- Slashing database cleared for lodestar, prysm, lighthouse, teku, and nimbus validator clients in both single-process and separate-process configurations
- Genesis initialization added for erigon
- Optionally run geth and erigon initialization as a non-root user, for instances where the service doesn't run as root
- Additional error handling around retrieval of GitHub release information
