### PR TITLE
Update geth-lighthouse and lighthouse-vc charts to the latest versions

### DIFF
--- a/charts/geth-lighthouse/Chart.yaml
+++ b/charts/geth-lighthouse/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 maintainers:
   - name: laibe

--- a/charts/geth-lighthouse/README.md
+++ b/charts/geth-lighthouse/README.md
@@ -1,6 +1,6 @@
 # geth-lighthouse
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart that spins up a post-merge ethereum node consisting of the go-ethereum (geth) execution client and the lighthouse consensus client.
 
@@ -48,7 +48,7 @@ Testnet rollback is automated via a CronJob that checks every five minutes wheth
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | geth.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | geth.image.repository | string | `"ethereum/client-go"` | Container image repository |
-| geth.image.tag | string | `"v1.12.0"` | Image tag |
+| geth.image.tag | string | `"v1.14.12"` | Image tag |
 | geth.jsonRpcInterface | string | `"0.0.0.0"` | Specify the listen address of the JSON-RPC API server for the execution client. |
 | geth.livenessProbe.initialDelaySeconds | int | `60` |  |
 | geth.livenessProbe.periodSeconds | int | `120` |  |
@@ -92,7 +92,7 @@ Testnet rollback is automated via a CronJob that checks every five minutes wheth
 | lighthouse.httpRestInterface | string | `"0.0.0.0"` | Specify the listen address of the lighthouse REST API server for the consensus client. |
 | lighthouse.image.pullPolicy | string | `"IfNotPresent"` |  |
 | lighthouse.image.repository | string | `"sigp/lighthouse"` | Container image repository |
-| lighthouse.image.tag | string | `"v4.2.0"` | Image tag |
+| lighthouse.image.tag | string | `"v6.0.1"` | Image tag |
 | lighthouse.livenessProbe.initialDelaySeconds | int | `60` |  |
 | lighthouse.livenessProbe.periodSeconds | int | `120` |  |
 | lighthouse.livenessProbe.tcpSocket.port | int | `5052` | Liveness probe tcpSocket port, default is the lighthouse httpRest port. |

--- a/charts/geth-lighthouse/values.yaml
+++ b/charts/geth-lighthouse/values.yaml
@@ -96,7 +96,7 @@ geth:
     # -- Container pull policy
     pullPolicy: IfNotPresent
     # -- Image tag
-    tag: v1.12.0
+    tag: v1.14.12
   ports:
     # -- [Execution-API](https://github.com/ethereum/execution-apis) port
     httpJsonRpc: 8545
@@ -139,7 +139,7 @@ lighthouse:
     repository: "sigp/lighthouse"
     pullPolicy: "IfNotPresent"
     # -- Image tag
-    tag: v4.2.0
+    tag: v6.0.1
   ports:
     # -- [Beacon-API](https://ethereum.github.io/beacon-APIs/) port
     httpRest: 5052

--- a/charts/lighthouse-vc/Chart.yaml
+++ b/charts/lighthouse-vc/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 maintainers:
   - name: laibe

--- a/charts/lighthouse-vc/values.yaml
+++ b/charts/lighthouse-vc/values.yaml
@@ -90,7 +90,7 @@ lighthouse:
     repository: "sigp/lighthouse"
     pullPolicy: "IfNotPresent"
     # -- Image tag
-    tag: v4.1.0
+    tag: v6.0.1
   ports:
     # -- [Validator Client API](https://lighthouse-book.sigmaprime.io/api-vc.html) port
     httpJson: 5062


### PR DESCRIPTION
helm-charts are still compatible with the latest versions, this just updates the default to

* geth `v1.14.12`
* lighthouse `v6.0.1`  